### PR TITLE
Disabled TextInput fixes

### DIFF
--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -305,7 +305,9 @@ func (t *TextInput) commandState(cmd textInputControlCommand, key ebiten.Key, de
 		}
 
 		if timer == nil {
-			t.commandToFunc[cmd]()
+			if !t.widget.Disabled {
+				t.commandToFunc[cmd]()
+			}
 
 			expired = &atomic.Value{}
 			expired.Store(false)


### PR DESCRIPTION
When disabled a text input will no longer respond to delete/movement commands