### PR TITLE
TextInput: EnterFunc API

### DIFF
--- a/_demo/main.go
+++ b/_demo/main.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
 
 	_ "image/png"
 
@@ -17,7 +18,8 @@ import (
 )
 
 type game struct {
-	ui *ebitenui.UI
+	uiEnabled bool
+	ui        *ebitenui.UI
 }
 
 type pageContainer struct {
@@ -40,7 +42,8 @@ func main() {
 	defer closeUI()
 
 	game := game{
-		ui: ui,
+		ui:        ui,
+		uiEnabled: true,
 	}
 
 	err = ebiten.RunGame(&game)
@@ -189,7 +192,7 @@ func demoContainer(res *uiResources, toolTips *toolTipContents, toolTip *widget.
 		sliderPage(res),
 		toolTipPage(res, toolTips, toolTip),
 		dragAndDropPage(res, dnd, drag),
-		textInputPage(res),
+		textInputPage(res, ui),
 		radioGroupPage(res),
 		windowPage(res, ui),
 		anchorLayoutPage(res),
@@ -369,10 +372,19 @@ func (g *game) Layout(outsideWidth int, outsideHeight int) (int, int) {
 }
 
 func (g *game) Update() error {
-	g.ui.Update()
+	if ebiten.IsKeyPressed(ebiten.KeyControl) && inpututil.IsKeyJustPressed(ebiten.KeyTab) {
+		g.uiEnabled = !g.uiEnabled
+	}
+	if g.uiEnabled {
+		g.ui.Update()
+	}
 	return nil
 }
 
 func (g *game) Draw(screen *ebiten.Image) {
-	g.ui.Draw(screen)
+	screen.Clear()
+
+	if g.uiEnabled {
+		g.ui.Draw(screen)
+	}
 }

--- a/_demo/page.go
+++ b/_demo/page.go
@@ -503,17 +503,17 @@ func textInputPage(res *uiResources, ui func() *ebitenui.UI) *page {
 		widget.TextInputOpts.CaretOpts(
 			widget.CaretOpts.Size(res.textInput.face, 2),
 		),
-		widget.TextInputOpts.EnterFunc(func(text string, enable widget.TextInputEnable) {
-			println("Enter:", text)
-			enable(false) // llint: disable the TextInput widget, until the window (3) is closed
-			openWindow3(res, ui, text, enable)
-		}),
 	}
 
 	t := widget.NewTextInput(append(
 		tOpts,
-		widget.TextInputOpts.Placeholder("Enter text here"))...,
-	)
+		widget.TextInputOpts.Placeholder("Enter text here"),
+		widget.TextInputOpts.EnterFunc(func(text string, enable widget.TextInputEnable) {
+			println("TextInput Enter:", text)
+			enable(false) // llint: disable the TextInput widget, until the window (3) is closed
+			openWindow3(res, ui, text, enable)
+		}),
+	)...)
 	c.AddChild(t)
 
 	tSecure := widget.NewTextInput(append(

--- a/widget/textinput.go
+++ b/widget/textinput.go
@@ -46,12 +46,12 @@ type TextInput struct {
 	secure          bool
 	secureInputText string
 
-	enterFunc TextEnterFunc
+	enterFunc TextInputEnterFunc
 }
 
 type TextInputEnable func(enable bool)
 
-type TextEnterFunc func(text string, enable TextInputEnable)
+type TextInputEnterFunc func(text string, enable TextInputEnable)
 
 type TextInputOpt func(t *TextInput)
 
@@ -137,7 +137,7 @@ func NewTextInput(opts ...TextInputOpt) *TextInput {
 	return t
 }
 
-func (o TextInputOptions) EnterFunc(enterFunc TextEnterFunc) TextInputOpt {
+func (o TextInputOptions) EnterFunc(enterFunc TextInputEnterFunc) TextInputOpt {
 	return func(t *TextInput) {
 		t.enterFunc = enterFunc
 	}


### PR DESCRIPTION
The TextInput seems to be missing one important feature: the ability for user to register a callback when the `Enter` key is pressed - the user is left the opportunities to react to the `Enter` event with the currently entered text.

ebitenui/widget/textinput.go: the `EnterFunc` support
ebitenui/_demo/page.go: example use case for the `EnterFunc` support

The changes should be pretty straightforward, please review this PR.