### PR TITLE
_examples: add imagebutton widget example

### DIFF
--- a/_examples/widget_demos/imagebutton/main.go
+++ b/_examples/widget_demos/imagebutton/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"image/color"
+	"log"
+
+	"github.com/ebitenui/ebitenui"
+	"github.com/ebitenui/ebitenui/image"
+	"github.com/ebitenui/ebitenui/widget"
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+)
+
+// Like button example, but use image instead of text for the label.
+
+// Game object used by Ebitengine.
+type game struct {
+	ui *ebitenui.UI
+}
+
+func main() {
+	// load images for button states: idle, hover, and pressed
+	buttonImage := loadButtonImage()
+	buttonIcon := loadButtonIcon()
+
+	// construct a new container that serves as the root of the UI hierarchy
+	rootContainer := widget.NewContainer(
+		// the container will use a plain color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.RGBA{0x13, 0x1a, 0x22, 0xff})),
+
+		// the container will use an anchor layout to layout its single child widget
+		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+	)
+
+	// We can achieve a button with image instead of text by using a combination of
+	// normal button (without text) and graphics widget.
+	// We bundle them together using a stacked layout container.
+	buttonStackedLayout := widget.NewContainer(
+		widget.ContainerOpts.Layout(widget.NewStackedLayout()),
+		// instruct the container's anchor layout to center the button both horizontally and vertically;
+		// since our button is a 2-widget object, we add the anchor info to the wrapping container
+		// instead of the button
+		widget.ContainerOpts.WidgetOpts(widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
+			HorizontalPosition: widget.AnchorLayoutPositionCenter,
+			VerticalPosition:   widget.AnchorLayoutPositionCenter,
+		})),
+	)
+	// construct a pressable button
+	button := widget.NewButton(
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			println("button clicked")
+		}),
+	)
+	buttonStackedLayout.AddChild(button)
+	// Put an image on top of the button, it will be centered.
+	// If your image doesn't fit the button and there is no Y stretching support,
+	// you may see a transparent rectangle inside the button.
+	// To fix that, either use a separate button image (that can fit the image)
+	// or add an appropriate stretching.
+	buttonStackedLayout.AddChild(widget.NewGraphic(widget.GraphicOpts.Image(buttonIcon)))
+
+	// since our button is a multi-widget object, add its wrapping container
+	rootContainer.AddChild(buttonStackedLayout)
+
+	// construct the UI
+	ui := ebitenui.UI{
+		Container: rootContainer,
+	}
+
+	// Ebiten setup
+	ebiten.SetWindowSize(400, 400)
+	ebiten.SetWindowTitle("Ebiten UI - ImageButton")
+
+	game := game{ui: &ui}
+
+	// run Ebiten main loop
+	err := ebiten.RunGame(&game)
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+// Layout implements Game.
+func (g *game) Layout(outsideWidth int, outsideHeight int) (int, int) {
+	return outsideWidth, outsideHeight
+}
+
+// Update implements Game.
+func (g *game) Update() error {
+	// update the UI
+	g.ui.Update()
+	return nil
+}
+
+// Draw implements Ebiten's Draw method.
+func (g *game) Draw(screen *ebiten.Image) {
+	// draw the UI onto the screen
+	g.ui.Draw(screen)
+}
+
+func loadButtonIcon() *ebiten.Image {
+	// we'll use a circle as an icon image
+	// in reality it could be an arbitrary *ebiten.Image
+	icon := ebiten.NewImage(32, 32)
+	ebitenutil.DrawCircle(icon, 16, 16, 16, color.RGBA{R: 0x71, G: 0x56, B: 0xbd, A: 255})
+	return icon
+}
+
+func loadButtonImage() *widget.ButtonImage {
+	idle := image.NewNineSliceColor(color.RGBA{R: 170, G: 170, B: 180, A: 255})
+	hover := image.NewNineSliceColor(color.RGBA{R: 130, G: 130, B: 150, A: 255})
+	pressed := image.NewNineSliceColor(color.RGBA{R: 100, G: 100, B: 120, A: 255})
+
+	return &widget.ButtonImage{
+		Idle:    idle,
+		Hover:   hover,
+		Pressed: pressed,
+	}
+}


### PR DESCRIPTION
This is a current way to implement a simple
image button with ebitenui.

Not to be confused with TextureButton which
usually means "no button outlines, just a sprite". An imagebutton is something that has both.
Imagine an inventory where every slot is a button
holding an image of an item. Or a menu where you
choose which units to build: every button is pressable and has unit icon as an image.