### PR TITLE
fix: set transparent color for NineSlice

### DIFF
--- a/image/nineslice.go
+++ b/image/nineslice.go
@@ -51,13 +51,16 @@ func NewNineSliceSimple(image *ebiten.Image, borderWidthHeight int, centerWidthH
 
 // NewNineSliceColor constructs a new NineSlice that when drawn fills with color c.
 func NewNineSliceColor(c color.Color) *NineSlice {
+	if c == nil {
+		return &NineSlice{transparent: true}
+	}
+
 	if n, ok := colorNineSlices[c]; ok {
 		return n
 	}
 
 	var n *NineSlice
-	_, _, _, a := c.RGBA()
-	if a == 0 {
+	if _, _, _, a := c.RGBA(); a == 0 {
 		n = &NineSlice{
 			transparent: true,
 		}

--- a/image/nineslice_test.go
+++ b/image/nineslice_test.go
@@ -31,3 +31,13 @@ func newImageEmptySize(width int, height int, t *testing.T) *ebiten.Image {
 	t.Helper()
 	return ebiten.NewImage(width, height)
 }
+
+func Test_NewNineSliceColor(t *testing.T) {
+	is := is.New(t)
+
+	n := NewNineSliceColor(nil)
+	is.Equal(n.transparent, true)
+
+	n = NewNineSliceColor(color.RGBA{0, 0, 0, 0})
+	is.Equal(n.transparent, true)
+}


### PR DESCRIPTION
- use the transparent color for the NineSlice when the color is nil