### PR TITLE
feat: add SetState for labeled checkbox

### DIFF
--- a/widget/labeledcheckbox.go
+++ b/widget/labeledcheckbox.go
@@ -59,6 +59,11 @@ func (o LabeledCheckboxOptions) Spacing(s int) LabeledCheckboxOpt {
 	}
 }
 
+func (l *LabeledCheckbox) SetState(state WidgetState) {
+	l.init.Do()
+	l.checkbox.SetState(state)
+}
+
 func (l *LabeledCheckbox) GetWidget() *Widget {
 	l.init.Do()
 	return l.container.GetWidget()

--- a/widget/labeledcheckbox_test.go
+++ b/widget/labeledcheckbox_test.go
@@ -13,8 +13,12 @@ func TestLabeledCheckbox_SetState_User(t *testing.T) {
 
 	l := newLabeledCheckbox(t)
 	leftMouseButtonClick(labeledCheckboxLabel(l), t)
-
 	is.Equal(l.Checkbox().State(), WidgetChecked)
+
+	l2 := newLabeledCheckbox(t)
+	l2.SetState(WidgetChecked)
+	leftMouseButtonClick(labeledCheckboxLabel(l2), t)
+	is.Equal(l2.Checkbox().State(), WidgetUnchecked)
 }
 
 func newLabeledCheckbox(t *testing.T, opts ...LabeledCheckboxOpt) *LabeledCheckbox {


### PR DESCRIPTION
Fixes issue #56 by adding a SetState function directly on the labeled checkbox which can initialize the checkbox object within.