### PR TITLE
Fix issue preselecting entry in combo box with many list entries

### DIFF
--- a/_examples/widget_demos/combobox/main.go
+++ b/_examples/widget_demos/combobox/main.go
@@ -41,7 +41,11 @@ func main() {
 		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
 	)
 
-	entries := []any{ListEntry{1, "Entry 1"}, ListEntry{2, "Entry 2"}, ListEntry{3, "Entry 3"}, ListEntry{4, "Entry 4"}, ListEntry{5, "Entry 5"}, ListEntry{6, "Entry 6"}}
+	numEntries := 20
+	entries := make([]any, 0, numEntries)
+	for i := 1; i <= numEntries; i++ {
+		entries = append(entries, ListEntry{i, fmt.Sprintf("Entry %d", i)})
+	}
 	// construct a combobox
 	comboBox := widget.NewListComboButton(
 		widget.ListComboButtonOpts.SelectComboButtonOpts(
@@ -120,8 +124,8 @@ func main() {
 			fmt.Println("Selected Entry: ", args.Entry)
 		}),
 	)
-	//Select the 4th entry -- optional
-	comboBox.SetSelectedEntry(entries[5])
+	//Select the middle entry -- optional
+	comboBox.SetSelectedEntry(entries[numEntries/2-1])
 
 	// add the button as a child of the container
 	rootContainer.AddChild(comboBox)

--- a/widget/list.go
+++ b/widget/list.go
@@ -446,6 +446,16 @@ func (l *List) setScrollLeft(left float64) {
 	l.scrollContainer.ScrollLeft = left
 }
 
+func scrollClamp(scroll float64) float64 {
+	min, max := -0.1, 0.1
+	if scroll < min {
+		scroll = min
+	} else if scroll > max {
+		scroll = max
+	}
+	return scroll
+}
+
 func (l *List) scrollVisible(w HasWidget) {
 	rect := l.scrollContainer.ContentRect()
 	wrect := w.GetWidget().Rect
@@ -462,10 +472,9 @@ func (l *List) scrollVisible(w HasWidget) {
 		} else if wrect.Min.X < rect.Min.X {
 			ScrollLeft = -float64(wrect.Min.X - rect.Min.X)
 		}
-		l.setScrollTop(l.scrollContainer.ScrollTop + ScrollTop)
-		l.setScrollLeft(l.scrollContainer.ScrollLeft + ScrollLeft)
+		l.setScrollTop(l.scrollContainer.ScrollTop + scrollClamp(ScrollTop/1000))
+		l.setScrollLeft(l.scrollContainer.ScrollLeft + scrollClamp(ScrollLeft/1000))
 	} else if wrect != rect {
 		l.prevFocusIndex = l.focusIndex
 	}
-
 }


### PR DESCRIPTION
Fixes #62. This is taking an approach similar to the [previous code](https://github.com/ebitenui/ebitenui/compare/v0.4.4...v0.5.0#diff-c250f77002aadfcf2a0bac1450056d4563eed035dc3e7948cf06ded8149bf549R449) where it moved the scroll list by only +/- 0.1 at time. So this introduces a simple clamp on that value after dividing by 1000, since the scroll functions multiply by 1000.

This at least fixes the issue at hand, if one were to want to have a smoother scroll regardless of how many items were in the list, it would require first knowing the total height of all entries to be able to find the right fraction. Since I wasn't sure if that would be available already I just went simple, feel free to improve upon it!


Also, provides an update to the combobox example to allow for easy testing of larger numbers of list entries. The code provided worked for me from list sizes of 12 all the way to 12000.