### PR TITLE
Added option to hide Container

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -265,6 +265,16 @@
 			"args": []
 		},
 		{
+			"name": "Launch Visibility",
+			"type": "go",
+			"request": "launch",
+			"mode": "debug",
+			"program": "${workspaceFolder}/_examples/widget_demos/visibility",
+			"cwd": "${workspaceFolder}/_examples/widget_demos/visibility",
+			"env": {},
+			"args": []
+		},
+		{
 			"name": "Launch Window",
 			"type": "go",
 			"request": "launch",

--- a/_examples/widget_demos/visibility/main.go
+++ b/_examples/widget_demos/visibility/main.go
@@ -49,6 +49,11 @@ func main() {
 			// Padding between elements
 			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(5)),
 		)),
+		widget.ContainerOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+				Stretch: true,
+			}),
+		),
 	)
 
 	// construct a new container for middle right of window
@@ -63,21 +68,21 @@ func main() {
 			// Padding between elements
 			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(30)),
 		)),
+		widget.ContainerOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+				Stretch: true,
+			}),
+			widget.WidgetOpts.MinSize(100, 100),
+		),
 	)
 
 	// construct a new container for middle of window
 	middleContainer := widget.NewContainer(
 		// the container will use a plain green color as its background
 		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0x00, 0xff, 0x00, 0xff})),
-
-		widget.ContainerOpts.Layout(widget.NewGridLayout(
-			// Define number of columns in the grid
-			widget.GridLayoutOpts.Columns(2),
-			// Define how to stretch the rows and columns. Note it is required to
-			// specify the Stretch for each row and column.
-			widget.GridLayoutOpts.Stretch([]bool{true, false}, []bool{true, true}),
-			// Padding between elements
-			widget.GridLayoutOpts.Padding(widget.NewInsetsSimple(5)),
+		widget.ContainerOpts.Layout(widget.NewRowLayout(
+			// Which direction to layout children
+			widget.RowLayoutOpts.Direction(widget.DirectionHorizontal),
 		)),
 	)
 	middleContainer.AddChild(middleLeftContainer)
@@ -103,7 +108,7 @@ func main() {
 
 		// add a handler that reacts to clicking the button
 		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
-			topContainer.GetWidget().Visibility = widget.Visibility_Hide
+			topContainer.GetWidget().Visibility = widget.Visibility_Hide_Blocking
 		}),
 	)
 	topContainer.AddChild(topButton)
@@ -150,7 +155,7 @@ func main() {
 
 		// add a handler that reacts to clicking the button
 		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
-			middleRightContainer.GetWidget().Visibility = widget.Visibility_None
+			middleRightContainer.GetWidget().Visibility = widget.Visibility_Hide
 		}),
 	)
 	middleLeftContainer.AddChild(middleShowButton)
@@ -190,7 +195,7 @@ func main() {
 			widget.GridLayoutOpts.Columns(1),
 			// Define how to stretch the rows and columns. Note it is required to
 			// specify the Stretch for each row and column.
-			widget.GridLayoutOpts.Stretch([]bool{true, false, true}, []bool{false, true, false}),
+			widget.GridLayoutOpts.Stretch([]bool{true, true}, []bool{false, true}),
 			// Padding between elements
 			widget.GridLayoutOpts.Padding(widget.Insets{
 				Top:    10,

--- a/_examples/widget_demos/visibility/main.go
+++ b/_examples/widget_demos/visibility/main.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"image/color"
+	"log"
+
+	"github.com/ebitenui/ebitenui"
+	"github.com/ebitenui/ebitenui/image"
+	"github.com/ebitenui/ebitenui/widget"
+	"github.com/golang/freetype/truetype"
+	"github.com/hajimehoshi/ebiten/v2"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+// Game object used by ebiten
+type game struct {
+	ui *ebitenui.UI
+}
+
+func main() {
+	// load images for button states: idle, hover, and pressed
+	buttonImage, _ := loadButtonImage()
+
+	// load button text font
+	face, _ := loadFont(20)
+
+	// construct a new container for top of window
+	topContainer := widget.NewContainer(
+		// the container will use a plain red color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0xff, 0x00, 0x00, 0xff})),
+		widget.ContainerOpts.Layout(widget.NewRowLayout(
+			// Set how far apart to space the children
+			widget.RowLayoutOpts.Spacing(15),
+			// Padding between elements
+			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(5)),
+		)),
+	)
+
+	// construct a new container for middle left of window
+	middleLeftContainer := widget.NewContainer(
+		// the container will use a plain red/green color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0xff, 0xff, 0x00, 0xff})),
+		widget.ContainerOpts.Layout(widget.NewRowLayout(
+			// Which direction to layout children
+			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+			// Set how far apart to space the children
+			widget.RowLayoutOpts.Spacing(15),
+			// Padding between elements
+			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(5)),
+		)),
+	)
+
+	// construct a new container for middle right of window
+	middleRightContainer := widget.NewContainer(
+		// the container will use a plain green/blue color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0x00, 0xff, 0xff, 0xff})),
+		widget.ContainerOpts.Layout(widget.NewRowLayout(
+			//Which direction to layout children
+			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+			// Spacing between elements
+			widget.RowLayoutOpts.Spacing(15),
+			// Padding between elements
+			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(30)),
+		)),
+	)
+
+	// construct a new container for middle of window
+	middleContainer := widget.NewContainer(
+		// the container will use a plain green color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0x00, 0xff, 0x00, 0xff})),
+
+		widget.ContainerOpts.Layout(widget.NewGridLayout(
+			// Define number of columns in the grid
+			widget.GridLayoutOpts.Columns(2),
+			// Define how to stretch the rows and columns. Note it is required to
+			// specify the Stretch for each row and column.
+			widget.GridLayoutOpts.Stretch([]bool{true, false}, []bool{true, true}),
+			// Padding between elements
+			widget.GridLayoutOpts.Padding(widget.NewInsetsSimple(5)),
+		)),
+	)
+	middleContainer.AddChild(middleLeftContainer)
+	middleContainer.AddChild(middleRightContainer)
+
+	// construct top button
+	topButton := widget.NewButton(
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		widget.ButtonOpts.Text("Hide top container (blocking)", face, &widget.ButtonTextColor{
+			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+		}),
+
+		// specify that the button's text needs some padding for correct display
+		widget.ButtonOpts.TextPadding(widget.Insets{
+			Left:   5,
+			Right:  5,
+			Top:    5,
+			Bottom: 5,
+		}),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			topContainer.GetWidget().Visibility = widget.Visibility_Hide
+		}),
+	)
+	topContainer.AddChild(topButton)
+
+	// construct middle buttons
+	middleShowButton := widget.NewButton(
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		widget.ButtonOpts.Text("Show blue container (non blocking)", face, &widget.ButtonTextColor{
+			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+		}),
+
+		// specify that the button's text needs some padding for correct display
+		widget.ButtonOpts.TextPadding(widget.Insets{
+			Left:   5,
+			Right:  5,
+			Top:    5,
+			Bottom: 5,
+		}),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			middleRightContainer.GetWidget().Visibility = widget.Visibility_Show
+		}),
+	)
+	middleHideButton := widget.NewButton(
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		widget.ButtonOpts.Text("Hide blue container (non blocking)", face, &widget.ButtonTextColor{
+			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+		}),
+
+		// specify that the button's text needs some padding for correct display
+		widget.ButtonOpts.TextPadding(widget.Insets{
+			Left:   5,
+			Right:  5,
+			Top:    5,
+			Bottom: 5,
+		}),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			middleRightContainer.GetWidget().Visibility = widget.Visibility_None
+		}),
+	)
+	middleLeftContainer.AddChild(middleShowButton)
+	middleLeftContainer.AddChild(middleHideButton)
+
+	// construct top button
+	buttonShowTop := widget.NewButton(
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		widget.ButtonOpts.Text("Show top container (blocking)", face, &widget.ButtonTextColor{
+			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+		}),
+
+		// specify that the button's text needs some padding for correct display
+		widget.ButtonOpts.TextPadding(widget.Insets{
+			Left:   5,
+			Right:  5,
+			Top:    5,
+			Bottom: 5,
+		}),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			topContainer.GetWidget().Visibility = widget.Visibility_Show
+		}),
+	)
+	middleLeftContainer.AddChild(buttonShowTop)
+
+	// build up rootContainer
+	rootContainer := widget.NewContainer(
+		// the container will use a plain white color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0xff, 0xff, 0xff, 0xff})),
+		widget.ContainerOpts.Layout(widget.NewGridLayout(
+			// Define number of columns in the grid
+			widget.GridLayoutOpts.Columns(1),
+			// Define how to stretch the rows and columns. Note it is required to
+			// specify the Stretch for each row and column.
+			widget.GridLayoutOpts.Stretch([]bool{true, false, true}, []bool{false, true, false}),
+			// Padding between elements
+			widget.GridLayoutOpts.Padding(widget.Insets{
+				Top:    10,
+				Bottom: 10,
+				Left:   10,
+				Right:  10,
+			}),
+		)),
+	)
+
+	rootContainer.AddChild(topContainer)
+	rootContainer.AddChild(middleContainer)
+
+	// construct the UI
+	ui := ebitenui.UI{
+		Container: rootContainer,
+	}
+
+	// Ebiten setup
+	ebiten.SetWindowSize(600, 600)
+	ebiten.SetWindowTitle("Ebiten UI - Visibility")
+	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
+
+	game := game{
+		ui: &ui,
+	}
+
+	// run Ebiten main loop
+	err := ebiten.RunGame(&game)
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+// Layout implements Game.
+func (g *game) Layout(outsideWidth int, outsideHeight int) (int, int) {
+	return outsideWidth, outsideHeight
+}
+
+// Update implements Game.
+func (g *game) Update() error {
+	// update the UI
+	g.ui.Update()
+	return nil
+}
+
+// Draw implements Ebiten's Draw method.
+func (g *game) Draw(screen *ebiten.Image) {
+	// draw the UI onto the screen
+	g.ui.Draw(screen)
+}
+
+func loadButtonImage() (*widget.ButtonImage, error) {
+	idle := image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 180, A: 255})
+
+	hover := image.NewNineSliceColor(color.NRGBA{R: 130, G: 130, B: 150, A: 255})
+
+	pressed := image.NewNineSliceColor(color.NRGBA{R: 100, G: 100, B: 120, A: 255})
+
+	return &widget.ButtonImage{
+		Idle:    idle,
+		Hover:   hover,
+		Pressed: pressed,
+	}, nil
+}
+
+func loadFont(size float64) (font.Face, error) {
+	ttfFont, err := truetype.Parse(goregular.TTF)
+	if err != nil {
+		return nil, err
+	}
+
+	return truetype.NewFace(ttfFont, &truetype.Options{
+		Size:    size,
+		DPI:     72,
+		Hinting: font.HintingFull,
+	}), nil
+}

--- a/_examples/widget_demos/visibility/main.go
+++ b/_examples/widget_demos/visibility/main.go
@@ -56,6 +56,25 @@ func main() {
 		),
 	)
 
+	// construct a new container for middle middle of window
+	middleMiddleContainer := widget.NewContainer(
+		// the container will use a plain red/green color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0xff, 0xff, 0xff, 0xff})),
+		widget.ContainerOpts.Layout(widget.NewRowLayout(
+			// Which direction to layout children
+			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+			// Set how far apart to space the children
+			widget.RowLayoutOpts.Spacing(15),
+			// Padding between elements
+			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(5)),
+		)),
+		widget.ContainerOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+				Stretch: true,
+			}),
+		),
+	)
+
 	// construct a new container for middle right of window
 	middleRightContainer := widget.NewContainer(
 		// the container will use a plain green/blue color as its background
@@ -86,6 +105,7 @@ func main() {
 		)),
 	)
 	middleContainer.AddChild(middleLeftContainer)
+	middleContainer.AddChild(middleMiddleContainer)
 	middleContainer.AddChild(middleRightContainer)
 
 	// construct top button

--- a/widget/anchorlayout.go
+++ b/widget/anchorlayout.go
@@ -87,7 +87,7 @@ func (a *AnchorLayout) Layout(widgets []PreferredSizeLocateableWidget, rect imag
 	}
 
 	widget := widgets[0]
-	if widget.GetWidget().Hidden {
+	if widget.GetWidget().Visibility == Visibility_None {
 		return
 	}
 

--- a/widget/anchorlayout.go
+++ b/widget/anchorlayout.go
@@ -87,6 +87,10 @@ func (a *AnchorLayout) Layout(widgets []PreferredSizeLocateableWidget, rect imag
 	}
 
 	widget := widgets[0]
+	if widget.GetWidget().Hidden {
+		return
+	}
+
 	ww, wh := widget.PreferredSize()
 	rect = a.padding.Apply(rect)
 	wx := 0

--- a/widget/anchorlayout.go
+++ b/widget/anchorlayout.go
@@ -87,7 +87,7 @@ func (a *AnchorLayout) Layout(widgets []PreferredSizeLocateableWidget, rect imag
 	}
 
 	widget := widgets[0]
-	if widget.GetWidget().Visibility == Visibility_None {
+	if widget.GetWidget().Visibility == Visibility_Hide {
 		return
 	}
 

--- a/widget/container.go
+++ b/widget/container.go
@@ -185,7 +185,7 @@ func (c *Container) SetLocation(rect img.Rectangle) {
 func (c *Container) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 	c.init.Do()
 
-	if c.widget.Visibility == Visibility_Hide || c.widget.Visibility == Visibility_None {
+	if c.widget.Visibility == Visibility_Hide_Blocking || c.widget.Visibility == Visibility_Hide {
 		return
 	}
 
@@ -203,7 +203,7 @@ func (c *Container) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 
 	for _, ch := range c.children {
 		if cr, ok := ch.(Renderer); ok {
-			if ch.GetWidget().Visibility == Visibility_Hide || ch.GetWidget().Visibility == Visibility_None {
+			if ch.GetWidget().Visibility == Visibility_Hide_Blocking || ch.GetWidget().Visibility == Visibility_Hide {
 				continue
 			}
 			cr.Render(screen, def)

--- a/widget/container.go
+++ b/widget/container.go
@@ -185,7 +185,7 @@ func (c *Container) SetLocation(rect img.Rectangle) {
 func (c *Container) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 	c.init.Do()
 
-	if c.widget.Hidden {
+	if c.widget.Visibility == Visibility_Hide || c.widget.Visibility == Visibility_None {
 		return
 	}
 
@@ -203,7 +203,7 @@ func (c *Container) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 
 	for _, ch := range c.children {
 		if cr, ok := ch.(Renderer); ok {
-			if ch.GetWidget().Hidden {
+			if ch.GetWidget().Visibility == Visibility_Hide || ch.GetWidget().Visibility == Visibility_None {
 				continue
 			}
 			cr.Render(screen, def)

--- a/widget/container.go
+++ b/widget/container.go
@@ -185,6 +185,10 @@ func (c *Container) SetLocation(rect img.Rectangle) {
 func (c *Container) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 	c.init.Do()
 
+	if c.widget.Hidden {
+		return
+	}
+
 	if c.AutoDisableChildren {
 		for _, ch := range c.children {
 			ch.GetWidget().Disabled = c.widget.Disabled
@@ -199,6 +203,9 @@ func (c *Container) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 
 	for _, ch := range c.children {
 		if cr, ok := ch.(Renderer); ok {
+			if ch.GetWidget().Hidden {
+				continue
+			}
 			cr.Render(screen, def)
 		}
 	}

--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -116,7 +116,7 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 	x, y := 0, 0
 	firstStretchedCol, firstStretchedRow := true, true
 	for _, w := range widgets {
-		if w.GetWidget().Visibility == Visibility_None {
+		if w.GetWidget().Visibility == Visibility_Hide {
 			continue
 		}
 

--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -116,7 +116,7 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 	x, y := 0, 0
 	firstStretchedCol, firstStretchedRow := true, true
 	for _, w := range widgets {
-		if w.GetWidget().Hidden {
+		if w.GetWidget().Visibility == Visibility_None {
 			continue
 		}
 

--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -116,6 +116,10 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 	x, y := 0, 0
 	firstStretchedCol, firstStretchedRow := true, true
 	for _, w := range widgets {
+		if w.GetWidget().Hidden {
+			continue
+		}
+
 		cw := colWidths[c]
 		if g.columnStretched(c) {
 			cw = stretchedColWidth

--- a/widget/rowlayout.go
+++ b/widget/rowlayout.go
@@ -108,7 +108,7 @@ func (r *RowLayout) layout(widgets []PreferredSizeLocateableWidget, rect image.R
 	x, y := 0, 0
 
 	for _, widget := range widgets {
-		if widget.GetWidget().Visibility == Visibility_None {
+		if widget.GetWidget().Visibility == Visibility_Hide {
 			continue
 		}
 

--- a/widget/rowlayout.go
+++ b/widget/rowlayout.go
@@ -108,7 +108,7 @@ func (r *RowLayout) layout(widgets []PreferredSizeLocateableWidget, rect image.R
 	x, y := 0, 0
 
 	for _, widget := range widgets {
-		if widget.GetWidget().Hidden {
+		if widget.GetWidget().Visibility == Visibility_None {
 			continue
 		}
 

--- a/widget/rowlayout.go
+++ b/widget/rowlayout.go
@@ -108,6 +108,10 @@ func (r *RowLayout) layout(widgets []PreferredSizeLocateableWidget, rect image.R
 	x, y := 0, 0
 
 	for _, widget := range widgets {
+		if widget.GetWidget().Hidden {
+			continue
+		}
+
 		wx, wy := x, y
 		ww, wh := widget.PreferredSize()
 

--- a/widget/stackedlayout.go
+++ b/widget/stackedlayout.go
@@ -54,7 +54,7 @@ func (a *StackedLayout) PreferredSize(widgets []PreferredSizeLocateableWidget) (
 	}
 	var w, h int
 	for idx, widget := range widgets {
-		if widget.GetWidget().Hidden {
+		if widget.GetWidget().Visibility == Visibility_None {
 			continue
 		}
 

--- a/widget/stackedlayout.go
+++ b/widget/stackedlayout.go
@@ -53,7 +53,11 @@ func (a *StackedLayout) PreferredSize(widgets []PreferredSizeLocateableWidget) (
 		return px, py
 	}
 	var w, h int
-	for idx := range widgets {
+	for idx, widget := range widgets {
+		if widget.GetWidget().Hidden {
+			continue
+		}
+
 		w1, h1 := widgets[idx].PreferredSize()
 		if w1 > w {
 			w = w1

--- a/widget/stackedlayout.go
+++ b/widget/stackedlayout.go
@@ -54,7 +54,7 @@ func (a *StackedLayout) PreferredSize(widgets []PreferredSizeLocateableWidget) (
 	}
 	var w, h int
 	for idx, widget := range widgets {
-		if widget.GetWidget().Visibility == Visibility_None {
+		if widget.GetWidget().Visibility == Visibility_Hide {
 			continue
 		}
 

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -119,9 +119,9 @@ type Dropper interface {
 type Visibility int
 
 const (
-	Visibility_Show Visibility = iota
-	Visibility_Hide            // Hide widget, but take up space
-	Visibility_None            // Hide widget, but don't take up space
+	Visibility_Show          Visibility = iota
+	Visibility_Hide_Blocking            // Hide widget, but take up space
+	Visibility_Hide                     // Hide widget, but don't take up space
 )
 
 // RenderFunc is a function that renders a widget onto screen. def may be called to defer

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -35,6 +35,10 @@ type Widget struct {
 	// the user's perspective, scrolling does not change state, but only the display of that state.
 	Disabled bool
 
+	// Hidden specififies whether the widget is visible. Hidden widgets should
+	// usually not render anything or react to user input.
+	Hidden bool
+
 	// CursorEnterEvent fires an event with *WidgetCursorEnterEventArgs when the cursor enters the widget's Rect.
 	CursorEnterEvent *event.Event
 

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -35,8 +35,8 @@ type Widget struct {
 	// the user's perspective, scrolling does not change state, but only the display of that state.
 	Disabled bool
 
-	// Hidden specififies whether the widget is visible. Hidden widgets should
-	// usually not render anything or react to user input.
+	// Hidden specifies whether the widget is visible. Hidden widgets should
+	// not render anything or react to user input.
 	Hidden bool
 
 	// CursorEnterEvent fires an event with *WidgetCursorEnterEventArgs when the cursor enters the widget's Rect.

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -37,7 +37,7 @@ type Widget struct {
 
 	// Hidden specifies whether the widget is visible. Hidden widgets should
 	// not render anything or react to user input.
-	Hidden bool
+	Visibility Visibility
 
 	// CursorEnterEvent fires an event with *WidgetCursorEnterEventArgs when the cursor enters the widget's Rect.
 	CursorEnterEvent *event.Event
@@ -115,6 +115,14 @@ type Focuser interface {
 type Dropper interface {
 	GetDropTargets() []HasWidget
 }
+
+type Visibility int
+
+const (
+	Visibility_Show Visibility = iota
+	Visibility_Hide            // Hide widget, but take up space
+	Visibility_None            // Hide widget, but don't take up space
+)
 
 // RenderFunc is a function that renders a widget onto screen. def may be called to defer
 // additional rendering.


### PR DESCRIPTION
I needed a way to hide containers but I couldn't figure out a way to do so. 

I plan to update the docs and add an example, but could you check if you like the way it was programmed before I do that. 

Thanks a lot! 

Example usage
```
buildingContainer := widget.NewContainer(
		// the container will use a plain color as its background
		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff})),

		// the container will use an anchor layout to layout its single child widget
		widget.ContainerOpts.Layout(widget.NewRowLayout(
			widget.RowLayoutOpts.Spacing(10),
			widget.RowLayoutOpts.Padding(widget.Insets{
				Top:    10,
				Bottom: 10,
				Left:   10,
				Right:  10,
			}),
		)),
	)
buildingContainer.Hidden = true
```