### PR TITLE
Make it possible to disable lists

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -332,6 +332,7 @@ func (l *List) createWidget() {
 	content := NewContainer(
 		ContainerOpts.Layout(NewRowLayout(
 			RowLayoutOpts.Direction(DirectionVertical))),
+		ContainerOpts.AutoDisableChildren(),
 	)
 
 	l.buttons = make([]*Button, 0, len(l.entries))


### PR DESCRIPTION
At the moment I believe it’s not possible to disable a list.
For instance doing this in the demo:
```
diff --git a/_examples/widget_demos/list/main.go b/_examples/widget_demos/list/main.go
index cb22494..6615104 100644
--- a/_examples/widget_demos/list/main.go
+++ b/_examples/widget_demos/list/main.go
@@ -93,8 +93,8 @@ func main() {
                        SelectedBackground:         color.NRGBA{R: 130, G: 130, B: 200, A: 255}, //Background color for the unfocused selected entry
                        SelectedFocusedBackground:  color.NRGBA{R: 130, G: 130, B: 170, A: 255}, //Background color for the focused selected entry
                        FocusedBackground:          color.NRGBA{R: 170, G: 170, B: 180, A: 255}, //Background color for the focused unselected entry
-                       DisabledUnselected:         color.NRGBA{100, 100, 100, 255},             //Foreground color for the disabled unselected entry
-                       DisabledSelected:           color.NRGBA{100, 100, 100, 255},             //Foreground color for the disabled selected entry
+                       DisabledUnselected:         color.NRGBA{120, 120, 120, 255},             //Foreground color for the disabled unselected entry
+                       DisabledSelected:           color.NRGBA{150, 150, 150, 255},             //Foreground color for the disabled selected entry
                        DisabledSelectedBackground: color.NRGBA{100, 100, 100, 255},             //Background color for the disabled selected entry
                }),
                //This required function returns the string displayed in the list
@@ -108,6 +108,7 @@ func main() {
                        fmt.Println("Is: ", args.Entry, " Was: ", args.PreviousEntry)
                }),
        )
+       list.GetWidget().Disabled = true

        //Add list to the root container
        rootContainer.AddChild(list)
```
doesn’t prevent from interacting with the list, select entries, etc…

Is there anything else needed? I tried to add a test in `widget/list_test.go` but it seems `SetSelectedEntry` works even when the list is disabled, probably by design.