### PR TITLE
Progress bar direction and invertion

### DIFF
--- a/_examples/widget_demos/progressbar/main.go
+++ b/_examples/widget_demos/progressbar/main.go
@@ -16,61 +16,108 @@ type game struct {
 }
 
 func main() {
-	// construct a new container that serves as the root of the UI hierarchy
+	// Construct a new container that serves as the root of the UI hierarchy.
 	rootContainer := widget.NewContainer(
-		// the container will use a plain color as its background
+		// The container will use a plain color as its background.
 		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff})),
 
-		// the container will use an anchor layout to layout its single child widget
+		// The container will use an anchor layout to lay out its single child.
 		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
 	)
 
-	// construct a progressbar
-	progressbar := widget.NewProgressBar(
-		widget.ProgressBarOpts.WidgetOpts(
-			//Set the required anchor layout data to determine where in
-			//the container to place the progressbar
+	// Construct a container to hold the progress bars.
+	progressBarsContainer := widget.NewContainer(
+		// The container will use a vertical row layout to lay out the progress
+		// bars in a vertical row.
+		widget.ContainerOpts.Layout(widget.NewRowLayout(
+			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+			widget.RowLayoutOpts.Spacing(20),
+		)),
+		// Set the required anchor layout data to determine where in the root
+		// container to place the progress bars.
+		widget.ContainerOpts.WidgetOpts(
 			widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
 				HorizontalPosition: widget.AnchorLayoutPositionCenter,
 				VerticalPosition:   widget.AnchorLayoutPositionCenter,
 			}),
-			//Set the minimum size for the progressbar.
-			//This is necessary if you wish to have the progressbar be larger than
-			//the provided track image. In this exampe since we are using NineSliceColor
-			//which is 1px x 1px we must set a minimum size.
+		),
+	)
+
+	// Construct a horizontal progress bar.
+	hProgressbar := widget.NewProgressBar(
+		widget.ProgressBarOpts.WidgetOpts(
+			// Set the minimum size for the progress bar.
+			// This is necessary if you wish to have the progress bar be larger than
+			// the provided track image. In this exampe since we are using NineSliceColor
+			// which is 1px x 1px we must set a minimum size.
 			widget.WidgetOpts.MinSize(200, 20),
 		),
 		widget.ProgressBarOpts.Images(
-			//Set the track images (Idle, Hover, Disabled)
+			// Set the track images (Idle, Hover, Disabled).
 			&widget.ProgressBarImage{
 				Idle:  image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
 				Hover: image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
 			},
-			//Set the progress images (Idle, Hover, Disabled)
+			// Set the progress images (Idle, Hover, Disabled).
 			&widget.ProgressBarImage{
 				Idle:  image.NewNineSliceColor(color.NRGBA{0, 0, 255, 255}),
 				Hover: image.NewNineSliceColor(color.NRGBA{0, 0, 255, 255}),
 			},
 		),
-		//Set the min, max, and current values
+		// Set the min, max, and current values.
 		widget.ProgressBarOpts.Values(0, 10, 7),
-		//Set how much of the track is displayed when the bar is overlayed.
+		// Set how much of the track is displayed when the bar is overlayed.
 		widget.ProgressBarOpts.TrackPadding(widget.Insets{
 			Top:    2,
 			Bottom: 2,
-			Left:   0,
-			Right:  0,
+		}),
+	)
+	// Construct a vertical inverted progress bar.
+	vProgressbar := widget.NewProgressBar(
+		// Set the direction of the progress bar to vertical.
+		widget.ProgressBarOpts.Direction(widget.DirectionVertical),
+		// Invert the progress bar, meaning here it will fill from the bottom to the top
+		// since it’s vertical.
+		widget.ProgressBarOpts.Inverted(true),
+		widget.ProgressBarOpts.WidgetOpts(
+			// Set the minimum size for the progress bar.
+			// This is necessary if you wish to have the progress bar be larger than
+			// the provided track image. In this example since we are using NineSliceColor
+			// which is 1px x 1px we must set a minimum size.
+			widget.WidgetOpts.MinSize(20, 200),
+		),
+		widget.ProgressBarOpts.Images(
+			// Set the track images (Idle, Hover, Disabled).
+			&widget.ProgressBarImage{
+				Idle:  image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
+				Hover: image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
+			},
+			// Set the progress images (Idle, Hover, Disabled).
+			&widget.ProgressBarImage{
+				Idle:  image.NewNineSliceColor(color.NRGBA{0, 255, 0, 255}),
+				Hover: image.NewNineSliceColor(color.NRGBA{0, 255, 0, 255}),
+			},
+		),
+		// Set the min, max, and current values.
+		widget.ProgressBarOpts.Values(0, 10, 4),
+		// Set how much of the track is displayed when the bar is overlayed.
+		widget.ProgressBarOpts.TrackPadding(widget.Insets{
+			Left:  2,
+			Right: 2,
 		}),
 	)
 	/*
-		To update the progressbar programmatically you can use
-		progressbar.SetCurrent(value)
-		progressbar.GetCurrent()
-		progressbar.Min = 5
-		progressbar.Max = 10
+		To update a progress bar programmatically you can use
+		hProgressbar.SetCurrent(value)
+		hProgressbar.GetCurrent()
+		hProgressbar.Min = 5
+		hProgressbar.Max = 10
 	*/
-	// add the progressbar as a child of the container
-	rootContainer.AddChild(progressbar)
+	// Add the progress bars as a child of their container.
+	progressBarsContainer.AddChild(hProgressbar)
+	progressBarsContainer.AddChild(vProgressbar)
+	// Add the progress bars container as a child of the root container.
+	rootContainer.AddChild(progressBarsContainer)
 
 	// construct the UI
 	ui := ebitenui.UI{
@@ -79,7 +126,7 @@ func main() {
 
 	// Ebiten setup
 	ebiten.SetWindowSize(400, 400)
-	ebiten.SetWindowTitle("Ebiten UI - Progressbar")
+	ebiten.SetWindowTitle("Ebiten UI - ProgressBar")
 
 	game := game{
 		ui: &ui,

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -15,6 +15,7 @@ type ProgressBar struct {
 
 	widgetOpts []WidgetOpt
 	direction  Direction
+	inverted   bool
 	trackImage *ProgressBarImage
 	fillImage  *ProgressBarImage
 
@@ -70,6 +71,12 @@ func (o ProgressBarOptions) WidgetOpts(opts ...WidgetOpt) ProgressBarOpt {
 func (o ProgressBarOptions) Direction(d Direction) ProgressBarOpt {
 	return func(s *ProgressBar) {
 		s.direction = d
+	}
+}
+
+func (o ProgressBarOptions) Inverted(inverted bool) ProgressBarOpt {
+	return func(s *ProgressBar) {
+		s.inverted = inverted
 	}
 }
 
@@ -152,12 +159,19 @@ func (s *ProgressBar) draw(screen *ebiten.Image) {
 		} else {
 			fillY = int(float64(fillY) * s.currentPercentage())
 		}
-		fill.Draw(screen, fillX, fillY, s.drawFillOptions)
+		fill.Draw(screen, fillX, fillY, func(opts *ebiten.DrawImageOptions) {
+			tx := s.widget.Rect.Min.X + s.trackPadding.Left
+			ty := s.widget.Rect.Min.Y + s.trackPadding.Top
+			if s.inverted {
+				if s.direction == DirectionHorizontal {
+					tx = s.widget.Rect.Max.X - s.trackPadding.Right - fillX
+				} else {
+					ty = s.widget.Rect.Max.Y - s.trackPadding.Bottom - fillY
+				}
+			}
+			opts.GeoM.Translate(float64(tx), float64(ty))
+		})
 	}
-}
-
-func (s *ProgressBar) drawFillOptions(opts *ebiten.DrawImageOptions) {
-	opts.GeoM.Translate(float64(s.GetWidget().Rect.Min.X+s.trackPadding.Left), float64(s.GetWidget().Rect.Min.Y+s.trackPadding.Top))
 }
 
 func (s *ProgressBar) currentPercentage() float64 {

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -14,6 +14,7 @@ type ProgressBar struct {
 	current int
 
 	widgetOpts []WidgetOpt
+	direction  Direction
 	trackImage *ProgressBarImage
 	fillImage  *ProgressBarImage
 
@@ -63,6 +64,12 @@ func NewProgressBar(opts ...ProgressBarOpt) *ProgressBar {
 func (o ProgressBarOptions) WidgetOpts(opts ...WidgetOpt) ProgressBarOpt {
 	return func(s *ProgressBar) {
 		s.widgetOpts = append(s.widgetOpts, opts...)
+	}
+}
+
+func (o ProgressBarOptions) Direction(d Direction) ProgressBarOpt {
+	return func(s *ProgressBar) {
+		s.direction = d
 	}
 }
 
@@ -139,9 +146,12 @@ func (s *ProgressBar) draw(screen *ebiten.Image) {
 	}
 	if fill != nil && s.currentPercentage() > 0 {
 		fillX := s.widget.Rect.Dx() - s.trackPadding.Left - s.trackPadding.Right
-		fillX = int(float64(fillX) * s.currentPercentage())
-
 		fillY := s.widget.Rect.Dy() - s.trackPadding.Top - s.trackPadding.Bottom
+		if s.direction == DirectionHorizontal {
+			fillX = int(float64(fillX) * s.currentPercentage())
+		} else {
+			fillY = int(float64(fillY) * s.currentPercentage())
+		}
 		fill.Draw(screen, fillX, fillY, s.drawFillOptions)
 	}
 }

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -65,12 +65,16 @@ func (o ProgressBarOptions) WidgetOpts(opts ...WidgetOpt) ProgressBarOpt {
 	}
 }
 
+// Direction sets the direction of the progress bar.
+// The default is horizontal.
 func (o ProgressBarOptions) Direction(d Direction) ProgressBarOpt {
 	return func(s *ProgressBar) {
 		s.direction = d
 	}
 }
 
+// Inverted sets whether the progress bar is inverted.
+// The default is false, which means from left to right or top to bottom.
 func (o ProgressBarOptions) Inverted(inverted bool) ProgressBarOpt {
 	return func(s *ProgressBar) {
 		s.inverted = inverted

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -21,9 +21,8 @@ type ProgressBar struct {
 
 	trackPadding Insets
 
-	init        *MultiOnce
-	widget      *Widget
-	lastCurrent int
+	init   *MultiOnce
+	widget *Widget
 }
 
 type ProgressBarImage struct {
@@ -47,8 +46,6 @@ func NewProgressBar(opts ...ProgressBarOpt) *ProgressBar {
 
 		trackImage: &ProgressBarImage{},
 		fillImage:  &ProgressBarImage{},
-
-		lastCurrent: 1,
 
 		init: &MultiOnce{},
 	}


### PR DESCRIPTION
This pull requests adds two features to the progress bar:
- vertical progress bars with `widget.ProgressBarOpts.Direction(widget.DirectionVertical)`, the default being horizontal
- inverted progress bars with `widget.ProgressBarOpts.Inverted(true)`, the default being obviously not inverted

As you can guess I had a need for a vertical progress bar filling from bottom to top 😄 

I’m happy to add anything to the examples if deemed needed, or to try to come up with a `progressbar_test.go` file, even!