### PR TITLE
Button released only if pressed

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -563,9 +563,7 @@ func (b *Button) createWidget() {
 		}),
 
 		WidgetOpts.MouseButtonReleasedHandler(func(args *WidgetMouseButtonReleasedEventArgs) {
-			b.pressing = false
-
-			if !b.widget.Disabled && args.Button == ebiten.MouseButtonLeft {
+			if b.pressing && !b.widget.Disabled && args.Button == ebiten.MouseButtonLeft {
 				b.ReleasedEvent.Fire(&ButtonReleasedEventArgs{
 					Button:  b,
 					Inside:  args.Inside,
@@ -590,6 +588,8 @@ func (b *Button) createWidget() {
 					}
 				}
 			}
+
+			b.pressing = false
 		}),
 	}...)...)
 	b.widgetOpts = nil

--- a/widget/button.go
+++ b/widget/button.go
@@ -332,23 +332,23 @@ func (o ButtonOptions) TabOrder(tabOrder int) ButtonOpt {
 	}
 }
 
-func (tw *Button) State() WidgetState {
-	return tw.state
+func (b *Button) State() WidgetState {
+	return b.state
 }
 
-func (tw *Button) SetState(state WidgetState) {
-	if state != tw.state {
-		tw.state = state
+func (b *Button) SetState(state WidgetState) {
+	if state != b.state {
+		b.state = state
 
-		tw.StateChangedEvent.Fire(&ButtonChangedEventArgs{
-			Button: tw,
-			State:  tw.state,
+		b.StateChangedEvent.Fire(&ButtonChangedEventArgs{
+			Button: b,
+			State:  b.state,
 		})
 	}
 }
 
-func (tw *Button) getStateChangedEvent() *event.Event {
-	return tw.StateChangedEvent
+func (b *Button) getStateChangedEvent() *event.Event {
+	return b.StateChangedEvent
 }
 
 func (b *Button) Configure(opts ...ButtonOpt) {


### PR DESCRIPTION
With
```
go run ./_examples/widget_demos/button/
```
if we press the mouse button outside the button, keep it pressed, then move the cursor to the button, and release the mouse button, then the button gets triggered and the console displays
```
button clicked
```

This is a really surprising and non usual behaviour. This pull request addresses this by making the button firing the released event only if it was pressed. This works independently of the fact that the mouse cursor leaves the button or not in-between.