### PR TITLE
Make button text position customizable

### DIFF
--- a/_examples/widget_demos/list/main.go
+++ b/_examples/widget_demos/list/main.go
@@ -54,7 +54,7 @@ func main() {
 	// Construct a list. This is one of the more complicated widgets to use since
 	// it is composed of multiple widget types
 	list := widget.NewList(
-		//Set how wide the list should be
+		// Set how wide the list should be
 		widget.ListOpts.ContainerOpts(widget.ContainerOpts.WidgetOpts(
 			widget.WidgetOpts.MinSize(150, 0),
 			widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
@@ -63,10 +63,10 @@ func main() {
 				StretchVertical:    true,
 			}),
 		)),
-		//Set the entries in the list
+		// Set the entries in the list
 		widget.ListOpts.Entries(entries),
 		widget.ListOpts.ScrollContainerOpts(
-			//Set the background images/color for the list
+			// Set the background images/color for the list
 			widget.ScrollContainerOpts.Image(&widget.ScrollContainerImage{
 				Idle:     image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
 				Disabled: image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
@@ -74,43 +74,45 @@ func main() {
 			}),
 		),
 		widget.ListOpts.SliderOpts(
-			//Set the background images/color for the background of the slider track
+			// Set the background images/color for the background of the slider track
 			widget.SliderOpts.Images(&widget.SliderTrackImage{
 				Idle:  image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
 				Hover: image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
 			}, buttonImage),
 			widget.SliderOpts.MinHandleSize(5),
-			//Set how wide the track should be
+			// Set how wide the track should be
 			widget.SliderOpts.TrackPadding(widget.NewInsetsSimple(2))),
-		//Hide the horizontal slider
+		// Hide the horizontal slider
 		widget.ListOpts.HideHorizontalSlider(),
-		//Set the font for the list options
+		// Set the font for the list options
 		widget.ListOpts.EntryFontFace(face),
-		//Set the colors for the list
+		// Set the colors for the list
 		widget.ListOpts.EntryColor(&widget.ListEntryColor{
-			Selected:                   color.NRGBA{0, 255, 0, 255},                 //Foreground color for the unfocused selected entry
-			Unselected:                 color.NRGBA{254, 255, 255, 255},             //Foreground color for the unfocused unselected entry
-			SelectedBackground:         color.NRGBA{R: 130, G: 130, B: 200, A: 255}, //Background color for the unfocused selected entry
-			SelectedFocusedBackground:  color.NRGBA{R: 130, G: 130, B: 170, A: 255}, //Background color for the focused selected entry
-			FocusedBackground:          color.NRGBA{R: 170, G: 170, B: 180, A: 255}, //Background color for the focused unselected entry
-			DisabledUnselected:         color.NRGBA{100, 100, 100, 255},             //Foreground color for the disabled unselected entry
-			DisabledSelected:           color.NRGBA{100, 100, 100, 255},             //Foreground color for the disabled selected entry
-			DisabledSelectedBackground: color.NRGBA{100, 100, 100, 255},             //Background color for the disabled selected entry
+			Selected:                   color.NRGBA{0, 255, 0, 255},                 // Foreground color for the unfocused selected entry
+			Unselected:                 color.NRGBA{254, 255, 255, 255},             // Foreground color for the unfocused unselected entry
+			SelectedBackground:         color.NRGBA{R: 130, G: 130, B: 200, A: 255}, // Background color for the unfocused selected entry
+			SelectedFocusedBackground:  color.NRGBA{R: 130, G: 130, B: 170, A: 255}, // Background color for the focused selected entry
+			FocusedBackground:          color.NRGBA{R: 170, G: 170, B: 180, A: 255}, // Background color for the focused unselected entry
+			DisabledUnselected:         color.NRGBA{100, 100, 100, 255},             // Foreground color for the disabled unselected entry
+			DisabledSelected:           color.NRGBA{100, 100, 100, 255},             // Foreground color for the disabled selected entry
+			DisabledSelectedBackground: color.NRGBA{100, 100, 100, 255},             // Background color for the disabled selected entry
 		}),
-		//This required function returns the string displayed in the list
+		// This required function returns the string displayed in the list
 		widget.ListOpts.EntryLabelFunc(func(e interface{}) string {
 			return e.(ListEntry).Name
 		}),
-		//Padding for each entry
+		// Padding for each entry
 		widget.ListOpts.EntryTextPadding(widget.NewInsetsSimple(5)),
-		//This handler defines what function to run when a list item is selected.
+		// Text position for each entry
+		widget.ListOpts.EntryTextPosition(widget.TextPositionStart, widget.TextPositionCenter),
+		// This handler defines what function to run when a list item is selected.
 		widget.ListOpts.EntrySelectedHandler(func(args *widget.ListEntrySelectedEventArgs) {
 			entry := args.Entry.(ListEntry)
 			fmt.Println("Entry Selected: ", entry)
 		}),
 	)
 
-	//Add list to the root container
+	// Add list to the root container
 	rootContainer.AddChild(list)
 
 	buttonsContainer := widget.NewContainer(

--- a/widget/button.go
+++ b/widget/button.go
@@ -28,6 +28,8 @@ type Button struct {
 
 	widgetOpts               []WidgetOpt
 	autoUpdateTextAndGraphic bool
+	vTextPosition            TextPosition
+	hTextPosition            TextPosition
 	textPadding              Insets
 	graphicPadding           Insets
 
@@ -106,6 +108,9 @@ var ButtonOpts ButtonOptions
 
 func NewButton(opts ...ButtonOpt) *Button {
 	b := &Button{
+		hTextPosition: TextPositionCenter,
+		vTextPosition: TextPositionCenter,
+
 		PressedEvent:       &event.Event{},
 		ReleasedEvent:      &event.Event{},
 		ClickedEvent:       &event.Event{},
@@ -137,30 +142,6 @@ func (o ButtonOptions) Image(i *ButtonImage) ButtonOpt {
 	}
 }
 
-func (o ButtonOptions) TextSimpleLeft(label string, face font.Face, color *ButtonTextColor, padding Insets) ButtonOpt {
-	return func(b *Button) {
-		b.init.Append(func() {
-			b.container = NewContainer(
-				ContainerOpts.Layout(NewAnchorLayout(AnchorLayoutOpts.Padding(padding))),
-				ContainerOpts.AutoDisableChildren(),
-			)
-
-			b.text = NewText(
-				TextOpts.WidgetOpts(WidgetOpts.LayoutData(AnchorLayoutData{
-					HorizontalPosition: AnchorLayoutPositionStart,
-					VerticalPosition:   AnchorLayoutPositionCenter,
-				})),
-				TextOpts.Text(label, face, color.Idle),
-				TextOpts.Position(TextPositionStart, TextPositionCenter),
-			)
-			b.container.AddChild(b.text)
-
-			b.autoUpdateTextAndGraphic = true
-			b.TextColor = color
-		})
-	}
-}
-
 func (o ButtonOptions) Text(label string, face font.Face, color *ButtonTextColor) ButtonOpt {
 	return func(b *Button) {
 		b.init.Append(func() {
@@ -171,11 +152,10 @@ func (o ButtonOptions) Text(label string, face font.Face, color *ButtonTextColor
 
 			b.text = NewText(
 				TextOpts.WidgetOpts(WidgetOpts.LayoutData(AnchorLayoutData{
-					HorizontalPosition: AnchorLayoutPositionCenter,
-					VerticalPosition:   AnchorLayoutPositionCenter,
+					HorizontalPosition: AnchorLayoutPosition(b.hTextPosition),
+					VerticalPosition:   AnchorLayoutPosition(b.vTextPosition),
 				})),
 				TextOpts.Text(label, face, color.Idle),
-				TextOpts.Position(TextPositionCenter, TextPositionCenter),
 			)
 			b.container.AddChild(b.text)
 
@@ -222,6 +202,15 @@ func (o ButtonOptions) TextAndImage(label string, face font.Face, image *ButtonI
 			b.GraphicImage = image
 			b.TextColor = color
 		})
+	}
+}
+
+// TextPosition sets the horizontal and vertical position of the text within the button.
+// Default is TextPositionCenter for both.
+func (o ButtonOptions) TextPosition(h TextPosition, v TextPosition) ButtonOpt {
+	return func(b *Button) {
+		b.hTextPosition = h
+		b.vTextPosition = v
 	}
 }
 

--- a/widget/list.go
+++ b/widget/list.go
@@ -17,21 +17,23 @@ import (
 type List struct {
 	EntrySelectedEvent *event.Event
 
-	containerOpts            []ContainerOpt
-	scrollContainerOpts      []ScrollContainerOpt
-	sliderOpts               []SliderOpt
-	entries                  []any
-	entryLabelFunc           ListEntryLabelFunc
-	entryFace                font.Face
-	entryUnselectedColor     *ButtonImage
-	entrySelectedColor       *ButtonImage
-	entryUnselectedTextColor *ButtonTextColor
-	entryTextColor           *ButtonTextColor
-	entryTextPadding         Insets
-	controlWidgetSpacing     int
-	hideHorizontalSlider     bool
-	hideVerticalSlider       bool
-	allowReselect            bool
+	containerOpts               []ContainerOpt
+	scrollContainerOpts         []ScrollContainerOpt
+	sliderOpts                  []SliderOpt
+	entries                     []any
+	entryLabelFunc              ListEntryLabelFunc
+	entryFace                   font.Face
+	entryUnselectedColor        *ButtonImage
+	entrySelectedColor          *ButtonImage
+	entryUnselectedTextColor    *ButtonTextColor
+	entryTextColor              *ButtonTextColor
+	entryTextPadding            Insets
+	entryTextHorizontalPosition TextPosition
+	entryTextVerticalPosition   TextPosition
+	controlWidgetSpacing        int
+	hideHorizontalSlider        bool
+	hideVerticalSlider          bool
+	allowReselect               bool
 
 	init            *MultiOnce
 	container       *Container
@@ -81,6 +83,9 @@ var ListOpts ListOptions
 func NewList(opts ...ListOpt) *List {
 	l := &List{
 		EntrySelectedEvent: &event.Event{},
+
+		entryTextHorizontalPosition: TextPositionCenter,
+		entryTextVerticalPosition:   TextPositionCenter,
 
 		init:           &MultiOnce{},
 		focusIndex:     0,
@@ -187,6 +192,15 @@ func (o ListOptions) EntryColor(c *ListEntryColor) ListOpt {
 func (o ListOptions) EntryTextPadding(i Insets) ListOpt {
 	return func(l *List) {
 		l.entryTextPadding = i
+	}
+}
+
+// EntryTextPosition sets the position of the text for entries.
+// Defaults to both TextPositionCenter.
+func (o ListOptions) EntryTextPosition(h TextPosition, v TextPosition) ListOpt {
+	return func(l *List) {
+		l.entryTextHorizontalPosition = h
+		l.entryTextVerticalPosition = v
 	}
 }
 
@@ -499,6 +513,7 @@ func (l *List) createEntry(entry any) *Button {
 		ButtonOpts.Image(l.entryUnselectedColor),
 		ButtonOpts.Text(l.entryLabelFunc(entry), l.entryFace, l.entryUnselectedTextColor),
 		ButtonOpts.TextPadding(l.entryTextPadding),
+		ButtonOpts.TextPosition(l.entryTextHorizontalPosition, l.entryTextVerticalPosition),
 		ButtonOpts.ClickedHandler(func(_ *ButtonClickedEventArgs) {
 			l.setSelectedEntry(entry, true)
 		}))


### PR DESCRIPTION
Actually the `TextOpts.Position` in the button construction wasn’t doing anything, because the position is defined by the wrapping AnchorLayout container.
I ended up removing the `TextOpts.Position` all together, and adding a cast from `TextPosition` to `AnchorLayoutPosition`. But I’m happy to make any change if needed!

With
```
diff --git a/_examples/demo/page.go b/_examples/demo/page.go
index bc91ffd..0a4d4d9 100644
--- a/_examples/demo/page.go
+++ b/_examples/demo/page.go
@@ -26,6 +26,7 @@ func buttonPage(res *uiResources) *page {
                        })),
                        widget.ButtonOpts.Image(res.button.image),
                        widget.ButtonOpts.Text(fmt.Sprintf("Button %d", i+1), res.button.face, res.button.text),
+                       widget.ButtonOpts.TextPosition(widget.TextPositionStart, widget.TextPositionCenter),
                        widget.ButtonOpts.TextPadding(res.button.padding),
                        widget.ButtonOpts.CursorEnteredHandler(func(args *widget.ButtonHoverEventArgs) { fmt.Println("Cursor Entered: " + args.Button.Text().Label) }),
                        widget.ButtonOpts.CursorExitedHandler(func(args *widget.ButtonHoverEventArgs) { fmt.Println("Cursor Exited: " + args.Button.Text().Label) }),
@@ -46,6 +47,7 @@ func buttonPage(res *uiResources) *page {
                        })),
                        widget.ButtonOpts.Image(res.button.image),
                        widget.ButtonOpts.Text(fmt.Sprintf("Toggle Button %d", i+1), res.button.face, res.button.text),
+                       widget.ButtonOpts.TextPosition(widget.TextPositionEnd, widget.TextPositionCenter),
                        widget.ButtonOpts.TextPadding(res.button.padding),
                        widget.ButtonOpts.CursorEnteredHandler(func(args *widget.ButtonHoverEventArgs) { fmt.Println("Cursor Entered: " + args.Button.Text().Label) }),
                        widget.ButtonOpts.CursorExitedHandler(func(args *widget.ButtonHoverEventArgs) { fmt.Println("Cursor Exited: " + args.Button.Text().Label) }),
```

the buttons demo page becomes

![image](https://github.com/ebitenui/ebitenui/assets/2386884/c82ef78c-2f9e-47fa-9b10-972bf26c4c4e)

and the list on the left still has correctly all text entries aligned to the left. 😄 

Solves #88 