### PR TITLE
Fix slider mouse scroll

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -377,7 +377,11 @@ func (l *List) createWidget() {
 			SliderOpts.PageSizeFunc(pageSizeFunc),
 			SliderOpts.DisableDefaultKeys(l.disableDefaultKeys),
 			SliderOpts.ChangedHandler(func(args *SliderChangedEventArgs) {
-				l.scrollContainer.ScrollTop = float64(args.Slider.Current) / 1000
+				current := args.Slider.Current
+				if pageSizeFunc() >= 1000 {
+					current = 0
+				}
+				l.scrollContainer.ScrollTop = float64(current) / 1000
 			}),
 		}...)...)
 		l.container.AddChild(l.vSlider)

--- a/widget/slider.go
+++ b/widget/slider.go
@@ -388,16 +388,13 @@ func (s *Slider) handleLengthAndTrackLength() (float64, float64) {
 		trackLength = float64(s.widget.Rect.Dy()) - float64(s.trackPadding.Top) - float64(s.trackPadding.Bottom)
 	}
 
-	length := float64(s.Max - s.Min + 1)
-
-	ps := s.pageSizeFunc()
-
 	handleLength := 0.0
-
 	if s.fixedHandleSize != 0 {
 		handleLength = float64(s.fixedHandleSize)
 	} else {
-		handleLength = float64(ps) / length * trackLength
+		ps := float64(s.pageSizeFunc())
+		length := float64(s.Max - s.Min + 1)
+		handleLength = ps / length * trackLength
 		if handleLength < float64(s.minHandleSize) {
 			handleLength = float64(s.minHandleSize)
 		}

--- a/widget/textarea.go
+++ b/widget/textarea.go
@@ -276,7 +276,14 @@ func (l *TextArea) createWidget() {
 			SliderOpts.MinMax(0, 1000),
 			SliderOpts.PageSizeFunc(pageSizeFunc),
 			SliderOpts.ChangedHandler(func(args *SliderChangedEventArgs) {
-				l.scrollContainer.ScrollTop = float64(args.Slider.Current) / 1000
+				current := args.Slider.Current
+				if pageSizeFunc() >= 1000 {
+					current = 0
+					if l.verticalScrollMode == ScrollEnd || l.verticalScrollMode == PositionAtEnd {
+						current = 1000
+					}
+				}
+				l.scrollContainer.ScrollTop = float64(current) / 1000
 			}),
 		}...)...)
 		if l.verticalScrollMode == ScrollEnd || l.verticalScrollMode == PositionAtEnd {
@@ -295,14 +302,23 @@ func (l *TextArea) createWidget() {
 	}
 
 	if l.showHorizontalSlider {
+		pageSizeFunc := func() int {
+			return int(math.Round(float64(l.scrollContainer.ContentRect().Dx()) / float64(content.GetWidget().Rect.Dx()) * 1000))
+		}
+
 		l.hSlider = NewSlider(append(l.sliderOpts, []SliderOpt{
 			SliderOpts.Direction(DirectionHorizontal),
 			SliderOpts.MinMax(0, 1000),
-			SliderOpts.PageSizeFunc(func() int {
-				return int(math.Round(float64(l.scrollContainer.ContentRect().Dx()) / float64(content.GetWidget().Rect.Dx()) * 1000))
-			}),
+			SliderOpts.PageSizeFunc(pageSizeFunc),
 			SliderOpts.ChangedHandler(func(args *SliderChangedEventArgs) {
-				l.scrollContainer.ScrollLeft = float64(args.Slider.Current) / 1000
+				current := args.Slider.Current
+				if pageSizeFunc() >= 1000 {
+					current = 0
+					if l.horizontalScrollMode == ScrollEnd || l.horizontalScrollMode == PositionAtEnd {
+						current = 1000
+					}
+				}
+				l.scrollContainer.ScrollLeft = float64(current) / 1000
 			}),
 		}...)...)
 		if l.horizontalScrollMode == ScrollEnd || l.horizontalScrollMode == PositionAtEnd {


### PR DESCRIPTION
When a list, text area or scroll container does not need scrolling because all its content is visible, the linked slider still fires events when changing its current position. This can happen when mouse scrolling on either the slider or the associated widget.

So, first the bug this is attempting to solve:

![mouse-scroll-bug](https://github.com/ebitenui/ebitenui/assets/2386884/9963684d-afb1-4913-9487-0e750bc38a93)

The lists, text areas, and scroll containers (basically all widgets that have sliders) are impacted.

Now, as for the fix, what this does is if the size of the drag part of the slider takes the whole space, then we revert any change to the `Current` field of the slider.
This is the simplest I came up with, we could change it a bit to e.g. keep the `Current` value, but not fire the `ChangedEvent`s.

But I’m not super happy with that, as it’s using a computation made for drawing the widget to take some behaviour decision…
Any suggestion?