### PR TITLE
Optimize text rendering for text area with a lot of lines

### DIFF
--- a/widget/text.go
+++ b/widget/text.go
@@ -175,6 +175,14 @@ func (t *Text) draw(screen *ebiten.Image) {
 	t.colorList.Push(&t.Color)
 
 	for i, line := range t.measurements.lines {
+		ly := int(math.Round(float64(p.Y) + t.measurements.lineHeight*float64(i) + t.measurements.ascent))
+		if ly > screen.Bounds().Max.Y+int(math.Round(t.measurements.ascent)) {
+			return
+		}
+		if ly < - int(math.Round(t.measurements.lineHeight-t.measurements.ascent)) {
+			continue
+		}
+
 		lx := p.X
 		switch t.horizontalPosition {
 		case TextPositionCenter:
@@ -184,8 +192,6 @@ func (t *Text) draw(screen *ebiten.Image) {
 		default:
 			lx += t.Inset.Left
 		}
-
-		ly := int(math.Round(float64(p.Y) + t.measurements.lineHeight*float64(i) + t.measurements.ascent))
 
 		if t.processBBCode {
 			spaceWidth := font.MeasureString(t.Face, " ").Round()

--- a/widget/text.go
+++ b/widget/text.go
@@ -119,7 +119,7 @@ func (o TextOptions) ProcessBBCode(processBBCode bool) TextOpt {
 	}
 }
 
-// This sets the max width the text will allow before wrapping to the next line
+// MaxWidth sets the max width the text will allow before wrapping to the next line
 func (o TextOptions) MaxWidth(maxWidth float64) TextOpt {
 	return func(t *Text) {
 		t.MaxWidth = maxWidth
@@ -168,7 +168,7 @@ func (t *Text) draw(screen *ebiten.Image) {
 	case TextPositionCenter:
 		p = p.Add(image.Point{0, int((float64(r.Dy()) - t.measurements.boundingBoxHeight) / 2)})
 	case TextPositionEnd:
-		p = p.Add(image.Point{0, int((float64(r.Dy()) - t.measurements.boundingBoxHeight))})
+		p = p.Add(image.Point{0, int(float64(r.Dy()) - t.measurements.boundingBoxHeight)})
 	}
 
 	t.colorList = &datastructures.Stack[color.Color]{}
@@ -190,10 +190,10 @@ func (t *Text) draw(screen *ebiten.Image) {
 		if t.processBBCode {
 			spaceWidth := font.MeasureString(t.Face, " ").Round()
 			for _, word := range line {
-				peices, updatedColor := t.handleBBCodeColor(word)
-				for _, peice := range peices {
-					text.Draw(screen, peice.text, t.Face, lx, ly, peice.color)
-					wordWidth := font.MeasureString(t.Face, peice.text)
+				pieces, updatedColor := t.handleBBCodeColor(word)
+				for _, piece := range pieces {
+					text.Draw(screen, piece.text, t.Face, lx, ly, piece.color)
+					wordWidth := font.MeasureString(t.Face, piece.text)
 					lx += wordWidth.Round()
 				}
 				text.Draw(screen, " ", t.Face, lx, ly, updatedColor)
@@ -292,12 +292,12 @@ func (t *Text) measure() {
 	for s.Scan() {
 		if t.MaxWidth > 0 {
 			var newLine []string
-			var newLineWidth float64 = float64(t.Inset.Left + t.Inset.Right)
+			newLineWidth := float64(t.Inset.Left + t.Inset.Right)
 			words := strings.Split(s.Text(), " ")
 			for _, word := range words {
 				wordWidth := fixedInt26_6ToFloat64(font.MeasureString(t.Face, word+" "))
 
-				//Strip out any bbcodes from size calculation
+				// Strip out any bbcodes from size calculation
 				if t.processBBCode {
 					if t.bbcodeRegex.MatchString(word) {
 						cleaned := t.bbcodeRegex.ReplaceAllString(word, "")
@@ -305,12 +305,12 @@ func (t *Text) measure() {
 					}
 				}
 
-				//If the new word doesnt push this past the max width continue adding to the current line
+				// If the new word doesn't push this past the max width continue adding to the current line
 				if newLineWidth+wordWidth < t.MaxWidth {
 					newLine = append(newLine, word)
 					newLineWidth += wordWidth
 				} else {
-					//If the new word would push this past the max width save off the current line and start a new one
+					// If the new word would push this past the max width save off the current line and start a new one
 					if len(newLine) != 0 {
 						t.measurements.lines = append(t.measurements.lines, newLine)
 						t.measurements.lineWidths = append(t.measurements.lineWidths, newLineWidth)
@@ -323,7 +323,7 @@ func (t *Text) measure() {
 					newLineWidth = wordWidth + float64(t.Inset.Left+t.Inset.Right)
 				}
 			}
-			//Save the final line
+			// Save the final line
 			if len(newLine) != 0 {
 				t.measurements.lines = append(t.measurements.lines, newLine)
 				t.measurements.lineWidths = append(t.measurements.lineWidths, newLineWidth)


### PR DESCRIPTION
Hi!

Here is a suggestion of an optimization mainly for text areas with lots of lines of text.

Making the following changes to the text area demo highlights the problem I was having: very low FPS (or TPS) when the text area contains a lot of lines, even when most of the lines are not displayed:
```
diff --git a/_examples/widget_demos/textarea/main.go b/_examples/widget_demos/textarea/main.go
index dcc165b..e1b0a96 100644
--- a/_examples/widget_demos/textarea/main.go
+++ b/_examples/widget_demos/textarea/main.go
@@ -10,6 +10,7 @@ import (
        "github.com/ebitenui/ebitenui/widget"
        "github.com/golang/freetype/truetype"
        "github.com/hajimehoshi/ebiten/v2"
+       "github.com/hajimehoshi/ebiten/v2/ebitenutil"
        "golang.org/x/image/font"
        "golang.org/x/image/font/gofont/goregular"
 )
@@ -34,6 +35,10 @@ func main() {
        )

        // construct a textarea
+       text := "Hello World\nTest1\nTest2\n[color=ff0000]Red[/color]\n[color=00ff00]Green[/color]\n[color=0000ff]Blue[/color]\nTest3\nTest4"
+       for line := 0; line < 1000; line++  {
+               text += fmt.Sprintf("\nline %d", line)
+       }
        textarea := widget.NewTextArea(
                widget.TextAreaOpts.ContainerOpts(
                        widget.ContainerOpts.WidgetOpts(
@@ -59,7 +64,7 @@ func main() {
                //Set the initial text for the textarea
                //It will automatically line wrap and process newlines characters
                //If ProcessBBCode is true it will parse out bbcode
-               widget.TextAreaOpts.Text("Hello World\nTest1\nTest2\n[color=ff0000]Red[/color]\n[color=00ff00]Green[/color]\n[color=0000ff]Blue[/color]\nTest3\nTest4"),
+               widget.TextAreaOpts.Text(text),
                //Tell the TextArea to show the vertical scrollbar
                widget.TextAreaOpts.ShowVerticalScrollbar(),
                //Set padding between edge of the widget and where the text is drawn
@@ -135,6 +140,7 @@ func (g *game) Update() error {
 func (g *game) Draw(screen *ebiten.Image) {
        // draw the UI onto the screen
        g.ui.Draw(screen)
+       ebitenutil.DebugPrint(screen, fmt.Sprintf("FPS: %f", ebiten.ActualFPS()))
 }

 func loadFont(size float64) (font.Face, error) {
```

Applying the changes from this pull request brings back the FPS to 60.

The first commit fixes typos, and such, but I can remove it if deemed unnecessary.