### PR TITLE
Add background colors when pressing list entries

### DIFF
--- a/_examples/widget_demos/list/main.go
+++ b/_examples/widget_demos/list/main.go
@@ -88,14 +88,16 @@ func main() {
 		widget.ListOpts.EntryFontFace(face),
 		// Set the colors for the list
 		widget.ListOpts.EntryColor(&widget.ListEntryColor{
-			Selected:                   color.NRGBA{0, 255, 0, 255},                 // Foreground color for the unfocused selected entry
-			Unselected:                 color.NRGBA{254, 255, 255, 255},             // Foreground color for the unfocused unselected entry
+			Selected:                   color.NRGBA{R: 0, G: 255, B: 0, A: 255},     // Foreground color for the unfocused selected entry
+			Unselected:                 color.NRGBA{R: 254, G: 255, B: 255, A: 255}, // Foreground color for the unfocused unselected entry
 			SelectedBackground:         color.NRGBA{R: 130, G: 130, B: 200, A: 255}, // Background color for the unfocused selected entry
+			SelectingBackground:        color.NRGBA{R: 130, G: 130, B: 130, A: 255}, // Background color for the unfocused being selected entry
+			SelectingFocusedBackground: color.NRGBA{R: 130, G: 140, B: 170, A: 255}, // Background color for the focused being selected entry
 			SelectedFocusedBackground:  color.NRGBA{R: 130, G: 130, B: 170, A: 255}, // Background color for the focused selected entry
 			FocusedBackground:          color.NRGBA{R: 170, G: 170, B: 180, A: 255}, // Background color for the focused unselected entry
-			DisabledUnselected:         color.NRGBA{100, 100, 100, 255},             // Foreground color for the disabled unselected entry
-			DisabledSelected:           color.NRGBA{100, 100, 100, 255},             // Foreground color for the disabled selected entry
-			DisabledSelectedBackground: color.NRGBA{100, 100, 100, 255},             // Background color for the disabled selected entry
+			DisabledUnselected:         color.NRGBA{R: 100, G: 100, B: 100, A: 255}, // Foreground color for the disabled unselected entry
+			DisabledSelected:           color.NRGBA{R: 100, G: 100, B: 100, A: 255}, // Foreground color for the disabled selected entry
+			DisabledSelectedBackground: color.NRGBA{R: 100, G: 100, B: 100, A: 255}, // Background color for the disabled selected entry
 		}),
 		// This required function returns the string displayed in the list
 		widget.ListOpts.EntryLabelFunc(func(e interface{}) string {

--- a/widget/list.go
+++ b/widget/list.go
@@ -62,8 +62,10 @@ type ListEntryColor struct {
 	Selected                   color.Color
 	DisabledUnselected         color.Color
 	DisabledSelected           color.Color
+	SelectingBackground        color.Color
 	SelectedBackground         color.Color
 	FocusedBackground          color.Color
+	SelectingFocusedBackground color.Color
 	SelectedFocusedBackground  color.Color
 	DisabledSelectedBackground color.Color
 }
@@ -170,12 +172,14 @@ func (o ListOptions) EntryColor(c *ListEntryColor) ListOpt {
 			Idle:     image.NewNineSliceColor(color.Transparent),
 			Disabled: image.NewNineSliceColor(color.Transparent),
 			Hover:    image.NewNineSliceColor(c.FocusedBackground),
+			Pressed:  image.NewNineSliceColor(c.SelectingBackground),
 		}
 
 		l.entrySelectedColor = &ButtonImage{
 			Idle:     image.NewNineSliceColor(c.SelectedBackground),
 			Disabled: image.NewNineSliceColor(c.DisabledSelectedBackground),
 			Hover:    image.NewNineSliceColor(c.SelectedFocusedBackground),
+			Pressed:  image.NewNineSliceColor(c.SelectingFocusedBackground),
 		}
 
 		l.entryUnselectedTextColor = &ButtonTextColor{


### PR DESCRIPTION
Adding a way to specify which colors the list entry buttons should have when pressing them.

Before

![before-list](https://github.com/ebitenui/ebitenui/assets/2386884/e54e0fd2-4904-4b4a-a02c-8ce47e3c032e)

After

![after-list](https://github.com/ebitenui/ebitenui/assets/2386884/e728fe0e-8594-4633-95ad-46ba761072f7)
