### PR TITLE
Fix tooltip and drag&drop outside scroll container

### DIFF
--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -173,6 +173,9 @@ func (d *DragAndDrop) idleState() dragAndDropState {
 		if !p.In(parent.GetWidget().Rect) && !d.dndTriggered {
 			return nil, false
 		}
+		if !parent.GetWidget().EffectiveInputLayer().ActiveFor(x, y, input.LayerEventTypeAny) {
+			return nil, false
+		}
 
 		return d.dragArmedState(x, y), true
 	}

--- a/widget/tooltip.go
+++ b/widget/tooltip.go
@@ -179,7 +179,6 @@ func (o ToolTipOptions) ToolTipUpdater(toolTipUpdater ToolTipUpdater) ToolTipOpt
 }
 
 func (t *ToolTip) Render(parent *Widget, screen *ebiten.Image, def DeferredRenderFunc) {
-
 	newState := t.state(parent)
 	if newState != nil {
 		t.state = newState
@@ -199,6 +198,9 @@ func (t *ToolTip) idleState() toolTipState {
 		x, y := input.CursorPosition()
 		p := image.Point{x, y}
 		if !p.In(parent.Rect) {
+			return nil
+		}
+		if !parent.EffectiveInputLayer().ActiveFor(x, y, input.LayerEventTypeAny) {
 			return nil
 		}
 


### PR DESCRIPTION
Hey!

The following patch applied to the `scrollcontainer` example shows that tooltips and drag&drops get triggered for elements outside the container.

```
diff --git a/_examples/widget_demos/scrollcontainer/main.go b/_examples/widget_demos/scrollcontainer/main.go
index ab7c4ae..b151707 100644
--- a/_examples/widget_demos/scrollcontainer/main.go
+++ b/_examples/widget_demos/scrollcontainer/main.go
@@ -20,6 +20,14 @@ type game struct {
 	ui *ebitenui.UI
 }
 
+type dndWidget struct {
+}
+
+func (dnd *dndWidget) Create(parent widget.HasWidget) (*widget.Container, interface{}) {
+	fmt.Println("create drag")
+	return nil, nil
+}
+
 func main() {
 	// load images for button states: idle, hover, and pressed
 	buttonImage, _ := loadButtonImage()
@@ -50,6 +58,13 @@ func main() {
 	for x := 0; x < 20; x++ {
 		//Capture x for use in callback
 		x := x
+		tooltip := widget.NewContainer(
+			widget.ContainerOpts.Layout(widget.NewRowLayout(widget.RowLayoutOpts.Direction(widget.DirectionVertical))),
+			widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255})),
+		)
+		tooltip.AddChild(widget.NewText(
+			widget.TextOpts.Text(fmt.Sprintf("Button %d", x), face, color.White),
+		))
 		// construct a button
 		button := widget.NewButton(
 			// set general widget options
@@ -58,6 +73,15 @@ func main() {
 				widget.WidgetOpts.LayoutData(widget.RowLayoutData{
 					Position: widget.RowLayoutPositionCenter,
 				}),
+				widget.WidgetOpts.EnableDragAndDrop(
+					widget.NewDragAndDrop(
+						widget.DragAndDropOpts.ContentsCreater(&dndWidget{}),
+					),
+				),
+				widget.WidgetOpts.ToolTip(widget.NewToolTip(
+					widget.ToolTipOpts.Content(tooltip),
+					widget.ToolTipOpts.Position(widget.TOOLTIP_POS_WIDGET),
+				)),
 			),
 
 			// specify the images to use
@@ -97,6 +121,11 @@ func main() {
 			Idle: image.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff}),
 			Mask: image.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff}),
 		}),
+		widget.ScrollContainerOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.GridLayoutData{
+				MaxHeight: 200,
+			}),
+		),
 	)
 	//Add the scrollable container to the left side of the window
 	rootContainer.AddChild(scrollContainer)
```

![scroll-container](https://github.com/ebitenui/ebitenui/assets/2386884/413ad862-5b75-4a60-be62-ce5630db2441)

It’s because the input layers are not checked beforehand, which this pull request fixes.