### PR TITLE
Fix drag&drop spurious updates

### DIFF
--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -225,7 +225,6 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 			droppable := false
 			var element HasWidget
 
-			u.Update(droppable, element, dragData)
 			args := &DragAndDropDroppedEventArgs{
 				Source:  parent,
 				SourceX: srcX,

--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -225,17 +225,17 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 			droppable := false
 			var element HasWidget
 
-			args := &DragAndDropDroppedEventArgs{
-				Source:  parent,
-				SourceX: srcX,
-				SourceY: srcY,
-				TargetX: x,
-				TargetY: y,
-				Data:    dragData,
-			}
 
 			if !input.KeyPressed(ebiten.KeyEscape) && !d.dndStopped {
 				p := image.Point{x, y}
+				args := &DragAndDropDroppedEventArgs{
+					Source:  parent,
+					SourceX: srcX,
+					SourceY: srcY,
+					TargetX: x,
+					TargetY: y,
+					Data:    dragData,
+				}
 				for _, target := range d.AvailableDropTargets {
 					if target.GetWidget().Visibility == Visibility_Hide {
 						continue


### PR DESCRIPTION
Hey!

With the following patch applied
```
diff --git a/_examples/widget_demos/draganddrop/main.go b/_examples/widget_demos/draganddrop/main.goindex 63b313d..6d63d33 100644
--- a/_examples/widget_demos/draganddrop/main.go
+++ b/_examples/widget_demos/draganddrop/main.go
@@ -62,12 +62,14 @@ func (dnd *dndWidget) Create(parent widget.HasWidget) (*widget.Container, interf //   - dragData - The drag data provided by the Create method above.
 func (dnd *dndWidget) Update(canDrop bool, targetWidget widget.HasWidget, dragData interface{}) {
        if canDrop {
+               fmt.Println("Can Drop")
                dnd.text.Label = "* Can Drop *"
                if targetWidget != nil {
                        targetWidget.(*widget.Container).BackgroundImage = image.NewNineSliceColor(color.NRGBA{100, 100, 255, 255})
                        dnd.targetedWidget = targetWidget
                }
        } else {
+               fmt.Println("Cannot Drop")
                dnd.text.Label = "Cannot Drop"
                if dnd.targetedWidget != nil {
                        dnd.targetedWidget.(*widget.Container).BackgroundImage = image.NewNineSliceColor(color.NRGBA{100, 100, 100, 255})
```
running `go run ./_examples/widget_demos/draganddrop/`, then dragging from the left widget to the top right one, we can see a stream of
```
…
Cannot Drop
Can Drop
…
```

Looking at the code, there is indeed always two calls to the update callback right after another: https://github.com/ebitenui/ebitenui/blob/ee583ac3e2a695dfcb50689ceaf9f155a8a49ae0/widget/dnd.go#L228-L248

This pull request drops the first one, which was always passing a `false` droppable and a `nil` widget.