### PR TITLE
Prevent drag and drop for hidden widgets

### DIFF
--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -238,6 +238,9 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 			if !input.KeyPressed(ebiten.KeyEscape) && !d.dndStopped {
 				p := image.Point{x, y}
 				for _, target := range d.AvailableDropTargets {
+					if target.GetWidget().Visibility == Visibility_Hide {
+						continue
+					}
 					if p.In(target.GetWidget().Rect) && target.GetWidget().canDrop(args) {
 						droppable = true
 						element = target
@@ -280,6 +283,9 @@ func (d *DragAndDrop) droppingState(srcX int, srcY int, x int, y int, dragData i
 		p := image.Point{x, y}
 		dropSuccessful := false
 		for _, target := range d.AvailableDropTargets {
+			if target.GetWidget().Visibility == Visibility_Hide {
+				continue
+			}
 			if p.In(target.GetWidget().Rect) && target.GetWidget().canDrop(args) {
 				if target.GetWidget().drop != nil {
 					args.Target = target


### PR DESCRIPTION
Hi!

This pull request fixes drag and drop callbacks being triggered for a widget with `widget.Visibility_Hide`.

The following diff adds basic drag&drop to the `_examples/widget_demos/visibility` demo to highlight the problem:
```
diff --git a/_examples/widget_demos/visibility/main.go b/_examples/widget_demos/visibility/main.go
index d46c46d..c7c30a2 100644
--- a/_examples/widget_demos/visibility/main.go
+++ b/_examples/widget_demos/visibility/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"image/color"
 	"log"
 
@@ -18,6 +19,14 @@ type game struct {
 	ui *ebitenui.UI
 }
 
+type drag struct {
+}
+
+func (d drag) Create(hasWidget widget.HasWidget) (*widget.Container, any) {
+	fmt.Println("create drag from yellow container")
+	return widget.NewContainer(), nil
+}
+
 func main() {
 	// load images for button states: idle, hover, and pressed
 	buttonImage, _ := loadButtonImage()
@@ -53,7 +62,11 @@ func main() {
 			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
 				Stretch: true,
 			}),
-		),
+			widget.WidgetOpts.EnableDragAndDrop(
+				widget.NewDragAndDrop(
+					widget.DragAndDropOpts.ContentsCreater(&drag{}),
+				),
+		)),
 	)
 
 	// construct a new container for middle middle of window
@@ -92,6 +105,13 @@ func main() {
 				Stretch: true,
 			}),
 			widget.WidgetOpts.MinSize(100, 100),
+			widget.WidgetOpts.CanDrop(func(args *widget.DragAndDropDroppedEventArgs) bool {
+				fmt.Println("can drop on blue container")
+				return true
+			}),
+			widget.WidgetOpts.Dropped(func(args *widget.DragAndDropDroppedEventArgs) {
+				fmt.Println("dropped on blue container")
+			}),
 		),
 	)
 
```
Running `go run ./_examples/widget_demos/visibility/`, and dragging from the yellow to the blue container prints the expected outputs.
Then clicking on the button to hide the blue container, and dragging again from the yellow container to where the blue one was, still incorrectly shows the same outputs: it shouldn’t because the blue container is now hidden.

![drag-hidden-widget](https://github.com/ebitenui/ebitenui/assets/2386884/19b00a04-c21d-4ad9-baf2-bf210b7f9d20)
