### PR TITLE
Fix drag drop update outside scroll container

### DIFF
--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -228,17 +228,17 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 			droppable := false
 			var element HasWidget
 
-			args := &DragAndDropDroppedEventArgs{
-				Source:  parent,
-				SourceX: srcX,
-				SourceY: srcY,
-				TargetX: x,
-				TargetY: y,
-				Data:    dragData,
-			}
 
 			if !input.KeyPressed(ebiten.KeyEscape) && !d.dndStopped {
 				p := image.Point{x, y}
+				args := &DragAndDropDroppedEventArgs{
+					Source:  parent,
+					SourceX: srcX,
+					SourceY: srcY,
+					TargetX: x,
+					TargetY: y,
+					Data:    dragData,
+				}
 				for _, target := range d.AvailableDropTargets {
 					if target.GetWidget().Visibility == Visibility_Hide {
 						continue

--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -228,7 +228,6 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 			droppable := false
 			var element HasWidget
 
-			u.Update(droppable, element, dragData)
 			args := &DragAndDropDroppedEventArgs{
 				Source:  parent,
 				SourceX: srcX,

--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -173,6 +173,9 @@ func (d *DragAndDrop) idleState() dragAndDropState {
 		if !p.In(parent.GetWidget().Rect) && !d.dndTriggered {
 			return nil, false
 		}
+		if !parent.GetWidget().EffectiveInputLayer().ActiveFor(x, y, input.LayerEventTypeAny) {
+			return nil, false
+		}
 
 		return d.dragArmedState(x, y), true
 	}

--- a/widget/dnd.go
+++ b/widget/dnd.go
@@ -228,7 +228,6 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 			droppable := false
 			var element HasWidget
 
-
 			if !input.KeyPressed(ebiten.KeyEscape) && !d.dndStopped {
 				p := image.Point{x, y}
 				args := &DragAndDropDroppedEventArgs{
@@ -243,7 +242,13 @@ func (d *DragAndDrop) draggingState(srcX int, srcY int, dragWidget *Container, d
 					if target.GetWidget().Visibility == Visibility_Hide {
 						continue
 					}
-					if p.In(target.GetWidget().Rect) && target.GetWidget().canDrop(args) {
+					if !p.In(target.GetWidget().Rect) {
+						continue
+					}
+					if !target.GetWidget().EffectiveInputLayer().ActiveFor(x, y, input.LayerEventTypeAny) {
+						continue
+					}
+					if target.GetWidget().canDrop(args) {
 						droppable = true
 						element = target
 						break
@@ -288,7 +293,13 @@ func (d *DragAndDrop) droppingState(srcX int, srcY int, x int, y int, dragData i
 			if target.GetWidget().Visibility == Visibility_Hide {
 				continue
 			}
-			if p.In(target.GetWidget().Rect) && target.GetWidget().canDrop(args) {
+			if !p.In(target.GetWidget().Rect) {
+				continue
+			}
+			if !target.GetWidget().EffectiveInputLayer().ActiveFor(x, y, input.LayerEventTypeAny) {
+				continue
+			}
+			if target.GetWidget().canDrop(args) {
 				if target.GetWidget().drop != nil {
 					args.Target = target
 					target.GetWidget().drop(args)

--- a/widget/tooltip.go
+++ b/widget/tooltip.go
@@ -179,7 +179,6 @@ func (o ToolTipOptions) ToolTipUpdater(toolTipUpdater ToolTipUpdater) ToolTipOpt
 }
 
 func (t *ToolTip) Render(parent *Widget, screen *ebiten.Image, def DeferredRenderFunc) {
-
 	newState := t.state(parent)
 	if newState != nil {
 		t.state = newState
@@ -199,6 +198,9 @@ func (t *ToolTip) idleState() toolTipState {
 		x, y := input.CursorPosition()
 		p := image.Point{x, y}
 		if !p.In(parent.Rect) {
+			return nil
+		}
+		if !parent.EffectiveInputLayer().ActiveFor(x, y, input.LayerEventTypeAny) {
 			return nil
 		}
 

--- a/widget/window.go
+++ b/widget/window.go
@@ -306,7 +306,7 @@ func (w *Window) SetupInputLayer(def input.DeferredSetupInputLayerFunc) {
 	w.container.GetWidget().ElevateToNewInputLayer(&input.Layer{
 		DebugLabel: "window",
 		EventTypes: input.LayerEventTypeAll,
-		BlockLower: true,
+		BlockLower: !w.Ephemeral,
 		FullScreen: w.Modal,
 		RectFunc: func() image.Rectangle {
 			return w.container.GetWidget().Rect


### PR DESCRIPTION
This PR comes on top of #107, #108, and only the last commit is new.
Sorry about that, I tried to make small easier to review PRs, but at this point it’s become hard to keep them all separate 😬

I’ll rebase this PR if/when the other PRs are merged, if that makes it easier to review.

Applying this [patch](https://github.com/ebitenui/ebitenui/files/13795617/patch.txt) to the `scrollcontainer` example exposes the following problem: the update and end callbacks are triggered with an element match on a widget that’s outside the scroll container.
This is shown in the following video where we press one of the buttons, then drag around outside the scroll viewport: the bug is the `update drag true` at the end.

![drag-hidden-widget-bis](https://github.com/ebitenui/ebitenui/assets/2386884/949b7383-78a4-4149-b351-56c8d9d4f493)
