### PR TITLE
Remove unused error prone key just pressed helper

### DIFF
--- a/input/input.go
+++ b/input/input.go
@@ -157,12 +157,6 @@ func AnyKeyPressed() bool {
 	return internalinput.InputHandler.AnyKeyPressed
 }
 
-// AnyKeyPressed returns whether key k has just been pressed.
-func KeyJustPressed(k ebiten.Key) bool {
-	p, ok := internalinput.InputHandler.KeyJustPressed[k]
-	return ok && p
-}
-
 // This method returns the drawable screen size whether it is fullscreen or not.
 func GetWindowSize() image.Point {
 	return windowSize

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -4,7 +4,6 @@ import (
 	"image"
 
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/inpututil"
 )
 
 type DefaultInternalHandler struct {
@@ -26,7 +25,6 @@ type DefaultInternalHandler struct {
 
 	InputChars     []rune
 	KeyPressed     map[ebiten.Key]bool
-	KeyJustPressed map[ebiten.Key]bool
 	AnyKeyPressed  bool
 	isTouched      bool
 	cursorImages   map[string]*ebiten.Image
@@ -35,7 +33,6 @@ type DefaultInternalHandler struct {
 
 var InputHandler *DefaultInternalHandler = &DefaultInternalHandler{
 	KeyPressed:     make(map[ebiten.Key]bool),
-	KeyJustPressed: make(map[ebiten.Key]bool),
 	cursorImages:   make(map[string]*ebiten.Image),
 	cursorOffset:   make(map[string]image.Point)}
 
@@ -69,7 +66,6 @@ func (handler *DefaultInternalHandler) Update() {
 	for k := ebiten.Key(0); k <= ebiten.KeyMax; k++ {
 		p := ebiten.IsKeyPressed(k)
 		handler.KeyPressed[k] = p
-		handler.KeyJustPressed[k] = inpututil.IsKeyJustPressed(k)
 		if p {
 			handler.AnyKeyPressed = true
 		}


### PR DESCRIPTION
All widgets use `input.IsKeyPressed` and an internal boolean state to store the 'just' side of it. The reason for this is that there may be two ebiten updates and only one rendering, therefore when this happens the keys are never just pressed when tested in the render method of widgets.
See for instance https://github.com/ebitenui/ebitenui/blob/ee583ac3e2a695dfcb50689ceaf9f155a8a49ae0/widget/list.go#L298-L299

or https://github.com/ebitenui/ebitenui/blob/ee583ac3e2a695dfcb50689ceaf9f155a8a49ae0/widget/slider.go#L283-L284

etc…

We might as well delete the `input.IsKeyJustPressed` input helper function given it cannot be relied upon.
An alternative would be to warn that this function should only be called from `Update` methods of ebiten, but I’m not sure it’d be that useful as opposed to directly call the ebiten function…