### PR TITLE
Fix list scrolling

### DIFF
--- a/_examples/widget_demos/scrollcontainer/main.go
+++ b/_examples/widget_demos/scrollcontainer/main.go
@@ -103,7 +103,7 @@ func main() {
 
 	//Create a function to return the page size used by the slider
 	pageSizeFunc := func() int {
-		return int(math.Round(float64(scrollContainer.ContentRect().Dy()) / float64(content.GetWidget().Rect.Dy()) * 1000))
+		return int(math.Round(float64(scrollContainer.ViewRect().Dy()) / float64(content.GetWidget().Rect.Dy()) * 1000))
 	}
 	//Create a vertical Slider bar to control the ScrollableContainer
 	vSlider := widget.NewSlider(

--- a/widget/list.go
+++ b/widget/list.go
@@ -566,20 +566,20 @@ func (l *List) scrollVisible(w HasWidget) {
 	rect := l.scrollContainer.ContentRect()
 	wrect := w.GetWidget().Rect
 	if !wrect.In(rect) {
-		ScrollTop := 0.0
-		ScrollLeft := 0.0
+		scrollTop := 0.0
+		scrollLeft := 0.0
 		if wrect.Max.Y > rect.Max.Y {
-			ScrollTop = float64(wrect.Max.Y - rect.Max.Y)
+			scrollTop = float64(wrect.Max.Y - rect.Max.Y)
 		} else if wrect.Min.Y < rect.Min.Y {
-			ScrollTop = float64(wrect.Min.Y - rect.Min.Y)
+			scrollTop = float64(wrect.Min.Y - rect.Min.Y)
 		}
 		if wrect.Max.X > rect.Max.X {
-			ScrollLeft = float64(wrect.Max.X - rect.Max.X)
+			scrollLeft = float64(wrect.Max.X - rect.Max.X)
 		} else if wrect.Min.X < rect.Min.X {
-			ScrollLeft = -float64(wrect.Min.X - rect.Min.X)
+			scrollLeft = -float64(wrect.Min.X - rect.Min.X)
 		}
-		l.setScrollTop(l.scrollContainer.ScrollTop + scrollClamp(ScrollTop/1000))
-		l.setScrollLeft(l.scrollContainer.ScrollLeft + scrollClamp(ScrollLeft/1000))
+		l.setScrollTop(l.scrollContainer.ScrollTop + scrollClamp(scrollTop/1000))
+		l.setScrollLeft(l.scrollContainer.ScrollLeft + scrollClamp(scrollLeft/1000))
 	} else if wrect != rect {
 		l.prevFocusIndex = l.focusIndex
 	}

--- a/widget/list.go
+++ b/widget/list.go
@@ -553,7 +553,7 @@ func (l *List) setScrollLeft(left float64) {
 }
 
 func scrollClamp(scroll float64) float64 {
-	min, max := -0.1, 0.1
+	const min, max = -0.1, 0.1
 	if scroll < min {
 		scroll = min
 	} else if scroll > max {

--- a/widget/list.go
+++ b/widget/list.go
@@ -379,7 +379,7 @@ func (l *List) createWidget() {
 
 	if !l.hideVerticalSlider {
 		pageSizeFunc := func() int {
-			return int(math.Round(float64(l.scrollContainer.ContentRect().Dy()) / float64(l.listContent.GetWidget().Rect.Dy()) * 1000))
+			return int(math.Round(float64(l.scrollContainer.ViewRect().Dy()) / float64(l.listContent.GetWidget().Rect.Dy()) * 1000))
 		}
 
 		l.vSlider = NewSlider(append(l.sliderOpts, []SliderOpt{
@@ -412,7 +412,7 @@ func (l *List) createWidget() {
 			SliderOpts.Direction(DirectionHorizontal),
 			SliderOpts.MinMax(0, 1000),
 			SliderOpts.PageSizeFunc(func() int {
-				return int(math.Round(float64(l.scrollContainer.ContentRect().Dx()) / float64(l.listContent.GetWidget().Rect.Dx()) * 1000))
+				return int(math.Round(float64(l.scrollContainer.ViewRect().Dx()) / float64(l.listContent.GetWidget().Rect.Dx()) * 1000))
 			}),
 			SliderOpts.ChangedHandler(func(args *SliderChangedEventArgs) {
 				l.scrollContainer.ScrollLeft = float64(args.Slider.Current) / 1000
@@ -563,7 +563,7 @@ func scrollClamp(scroll float64) float64 {
 }
 
 func (l *List) scrollVisible(w HasWidget) {
-	rect := l.scrollContainer.ContentRect()
+	rect := l.scrollContainer.ViewRect()
 	wrect := w.GetWidget().Rect
 	if !wrect.In(rect) {
 		scrollTop := 0.0

--- a/widget/scrollcontainer.go
+++ b/widget/scrollcontainer.go
@@ -134,7 +134,7 @@ func (s *ScrollContainer) SetupInputLayer(def input.DeferredSetupInputLayerFunc)
 		EventTypes: input.LayerEventTypeAll ^ input.LayerEventTypeWheel,
 		BlockLower: true,
 		FullScreen: false,
-		RectFunc:   s.ContentRect,
+		RectFunc:   s.ViewRect,
 	})
 
 	if il, ok := s.content.(input.Layerer); ok {
@@ -228,16 +228,16 @@ func (s *ScrollContainer) renderContent(screen *ebiten.Image, def DeferredRender
 			cw, ch = p.PreferredSize()
 		}
 
-		crect := s.ContentRect()
-		if s.stretchContentWidth && cw < crect.Dx() {
-			cw = crect.Dx()
+		vrect := s.ViewRect()
+		if s.stretchContentWidth && cw < vrect.Dx() {
+			cw = vrect.Dx()
 		}
 
 		rect := img.Rect(0, 0, cw, ch)
 		rect = rect.Add(s.widget.Rect.Min)
 		rect = rect.Add(img.Point{s.padding.Left, s.padding.Top})
 
-		rect = rect.Sub(img.Point{int(math.Round(float64(cw-crect.Dx()) * s.ScrollLeft)), int(math.Round(float64(ch-crect.Dy()) * s.ScrollTop))})
+		rect = rect.Sub(img.Point{int(math.Round(float64(cw-vrect.Dx()) * s.ScrollLeft)), int(math.Round(float64(ch-vrect.Dy()) * s.ScrollTop))})
 
 		if rect != s.content.GetWidget().Rect {
 			l.SetLocation(rect)
@@ -260,7 +260,7 @@ func (s *ScrollContainer) renderContent(screen *ebiten.Image, def DeferredRender
 		})
 }
 
-func (s *ScrollContainer) ContentRect() img.Rectangle {
+func (s *ScrollContainer) ViewRect() img.Rectangle {
 	s.init.Do()
 	return s.padding.Apply(s.widget.Rect)
 }

--- a/widget/scrollcontainer.go
+++ b/widget/scrollcontainer.go
@@ -265,6 +265,10 @@ func (s *ScrollContainer) ViewRect() img.Rectangle {
 	return s.padding.Apply(s.widget.Rect)
 }
 
+func (s *ScrollContainer) ContentRect() img.Rectangle {
+	return s.content.GetWidget().Rect
+}
+
 func (s *ScrollContainer) clampScroll() {
 	if s.ScrollTop < 0 {
 		s.ScrollTop = 0

--- a/widget/textarea.go
+++ b/widget/textarea.go
@@ -268,7 +268,7 @@ func (l *TextArea) createWidget() {
 
 	if l.showVerticalSlider {
 		pageSizeFunc := func() int {
-			return int(math.Round(float64(l.scrollContainer.ContentRect().Dy()) / float64(content.GetWidget().Rect.Dy()) * 1000))
+			return int(math.Round(float64(l.scrollContainer.ViewRect().Dy()) / float64(content.GetWidget().Rect.Dy()) * 1000))
 		}
 
 		l.vSlider = NewSlider(append(l.sliderOpts, []SliderOpt{
@@ -303,7 +303,7 @@ func (l *TextArea) createWidget() {
 
 	if l.showHorizontalSlider {
 		pageSizeFunc := func() int {
-			return int(math.Round(float64(l.scrollContainer.ContentRect().Dx()) / float64(content.GetWidget().Rect.Dx()) * 1000))
+			return int(math.Round(float64(l.scrollContainer.ViewRect().Dx()) / float64(content.GetWidget().Rect.Dx()) * 1000))
 		}
 
 		l.hSlider = NewSlider(append(l.sliderOpts, []SliderOpt{


### PR DESCRIPTION
Hey!

This pull request fixes the list scrolling.

Applying this [this patch](https://github.com/ebitenui/ebitenui/files/13851396/scroll-container-broken-scroll.txt) and running `go run _examples/widget_demos/list` demonstrates part of the issue.
The following video shows what happens when manually scrolling to the bottom, then clicking the button to select entry 20: the scrolling to show the entry ends up with it well inside the view instead of the first element at the top of the view.

![scroll-container-broken-scrolling](https://github.com/ebitenui/ebitenui/assets/2386884/811aa05d-9d9c-4c0e-9cd0-76ba10e8970d)

Changing this line in `_examples/widget_demos/list/main.go`
```
	numEntries := 40
```
to
```
	numEntries := 300
```
then running the example again, and clicking the button to select entry 20, highlights another problem that cannot be captured very well in a video: the scrolling moves up and down every frame resulting in a constant blurred list view.

The fix in this pull request starts by renaming the `scrollcontainer.ContentRect` method to `scrollcontainer.ViewRect` because it’s actually what it is: the rect for the current visible part of the container, not of the underlying part with all the content.
It then introduces a «real» `scrollcontainer.ContentRect` method, that’s needed to properly compute the scrolling when making a widget visible in the view.

The first 2 commits could probably be merged into the 4th, I can do that if needed.
Or even squash all the commits…