### PR TITLE
Fix crash when stretch arrays are set but not long enough to account for all columns and rows

### DIFF
--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -198,11 +198,11 @@ func (g *GridLayout) stretchedCellSizes(colWidths []int, rowHeights []int, rect 
 }
 
 func (g *GridLayout) columnStretched(c int) bool {
-	return g.columnStretch != nil && g.columnStretch[c]
+	return g.columnStretch != nil && c < len(g.columnStretch) && g.columnStretch[c]
 }
 
 func (g *GridLayout) rowStretched(r int) bool {
-	return g.rowStretch != nil && g.rowStretch[r]
+	return g.rowStretch != nil && r < len(g.rowStretch) && g.rowStretch[r]
 }
 
 func (g *GridLayout) preferredColumnWidthsAndRowHeights(widgets []PreferredSizeLocateableWidget) ([]int, []int) {


### PR DESCRIPTION
Very simple change that makes ebitenui easier to use