### PR TITLE
Update Cursor Management

### DIFF
--- a/_examples/widget_demos/cursor_shape/main.go
+++ b/_examples/widget_demos/cursor_shape/main.go
@@ -105,19 +105,19 @@ func main() {
 		ui: &ui,
 	}
 
-	//Set the main cursor used within the application
+	// Set the main cursor used within the application
 	input.SetCursorImage(input.CURSOR_DEFAULT, loadNormalCursorImage())
 
-	//Set the custom hover image
+	// Set the custom hover image
 	input.SetCursorImage("buttonHover", loadHoverCursorImage())
 
 	input.SetCursorImage("buttonPressed", loadPressedCursorImage())
 
-	//Set the NS resize cursor with an offset so that it shows up a little above the cursor point
+	// Set the NS resize cursor with an offset so that it shows up a little above the cursor point
 	input.SetCursorImageWithOffset(input.CURSOR_NSRESIZE, loadNSCursorImage(), image.Point{0, -6})
 
-	//Disable cursor management by ebitenui
-	//input.CursorManagementEnabled = false
+	// Disable cursor management by ebitenui
+	// input.CursorManagementEnabled = false
 
 	// run Ebiten main loop
 	err := ebiten.RunGame(&game)

--- a/widget/button_test.go
+++ b/widget/button_test.go
@@ -72,7 +72,8 @@ func newButton(t *testing.T, opts ...ButtonOpt) *Button {
 	t.Helper()
 
 	b := NewButton(append(opts, ButtonOpts.Image(&ButtonImage{
-		Idle: newNineSliceEmpty(t),
+		Idle:    newNineSliceEmpty(t),
+		Pressed: newNineSliceEmpty(t),
 	}))...)
 	event.ExecuteDeferred()
 	render(b, t)

--- a/widget/checkbox_test.go
+++ b/widget/checkbox_test.go
@@ -102,7 +102,8 @@ func newCheckbox(t *testing.T, opts ...CheckboxOpt) *Checkbox {
 
 	c := NewCheckbox(append(opts, []CheckboxOpt{
 		CheckboxOpts.ButtonOpts(ButtonOpts.Image(&ButtonImage{
-			Idle: newNineSliceEmpty(t),
+			Idle:    newNineSliceEmpty(t),
+			Pressed: newNineSliceEmpty(t),
 		})),
 
 		CheckboxOpts.Image(&CheckboxGraphicImage{

--- a/widget/combobutton_test.go
+++ b/widget/combobutton_test.go
@@ -24,7 +24,8 @@ func newComboButton(t *testing.T, opts ...ComboButtonOpt) *ComboButton {
 
 	b := NewComboButton(append(opts, []ComboButtonOpt{
 		ComboButtonOpts.ButtonOpts(ButtonOpts.Image(&ButtonImage{
-			Idle: newNineSliceEmpty(t),
+			Idle:    newNineSliceEmpty(t),
+			Pressed: newNineSliceEmpty(t),
 		})),
 		ComboButtonOpts.Content(newButton(t)),
 	}...)...)

--- a/widget/labeledcheckbox_test.go
+++ b/widget/labeledcheckbox_test.go
@@ -38,7 +38,8 @@ func newLabeledCheckbox(t *testing.T, opts ...LabeledCheckboxOpt) *LabeledCheckb
 	l := NewLabeledCheckbox(append(opts, []LabeledCheckboxOpt{
 		LabeledCheckboxOpts.CheckboxOpts(
 			CheckboxOpts.ButtonOpts(ButtonOpts.Image(&ButtonImage{
-				Idle: newNineSliceEmpty(t),
+				Idle:    newNineSliceEmpty(t),
+				Pressed: newNineSliceEmpty(t),
 			})),
 			CheckboxOpts.Image(&CheckboxGraphicImage{
 				Unchecked: &ButtonImageImage{

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -136,7 +136,8 @@ func newList(t *testing.T, opts ...ListOpt) *List {
 		})),
 
 		ListOpts.SliderOpts(SliderOpts.Images(&SliderTrackImage{}, &ButtonImage{
-			Idle: newNineSliceEmpty(t),
+			Idle:    newNineSliceEmpty(t),
+			Pressed: newNineSliceEmpty(t),
 		})),
 
 		ListOpts.EntryFontFace(loadFont(t)),

--- a/widget/listcombobutton_test.go
+++ b/widget/listcombobutton_test.go
@@ -157,7 +157,8 @@ func newListComboButton(t *testing.T, opts ...ListComboButtonOpt) *ListComboButt
 
 	l := NewListComboButton(append(opts, []ListComboButtonOpt{
 		ListComboButtonOpts.SelectComboButtonOpts(SelectComboButtonOpts.ComboButtonOpts(ComboButtonOpts.ButtonOpts(ButtonOpts.Image(&ButtonImage{
-			Idle: newNineSliceEmpty(t),
+			Idle:    newNineSliceEmpty(t),
+			Pressed: newNineSliceEmpty(t),
 		})))),
 		ListComboButtonOpts.ListOpts(
 			ListOpts.ScrollContainerOpts(ScrollContainerOpts.Image(&ScrollContainerImage{
@@ -166,7 +167,8 @@ func newListComboButton(t *testing.T, opts ...ListComboButtonOpt) *ListComboButt
 				Mask:     newNineSliceEmpty(t),
 			})),
 			ListOpts.SliderOpts(SliderOpts.Images(&SliderTrackImage{}, &ButtonImage{
-				Idle: newNineSliceEmpty(t),
+				Idle:    newNineSliceEmpty(t),
+				Pressed: newNineSliceEmpty(t),
 			})),
 			ListOpts.EntryColor(&ListEntryColor{
 				Unselected:                 color.Transparent,

--- a/widget/selectcombobutton_test.go
+++ b/widget/selectcombobutton_test.go
@@ -15,10 +15,6 @@ func TestSelectComboButton_SetSelectedEntry(t *testing.T) {
 	numEvents := 0
 
 	b := newSelectComboButton(t,
-		SelectComboButtonOpts.EntryLabelFunc(func(e interface{}) string {
-			return "label " + e.(string)
-		}),
-
 		SelectComboButtonOpts.EntrySelectedHandler(func(args *SelectComboButtonEntrySelectedEventArgs) {
 			eventArgs = args
 			numEvents++
@@ -79,7 +75,8 @@ func newSelectComboButton(t *testing.T, opts ...SelectComboButtonOpt) *SelectCom
 		SelectComboButtonOpts.ComboButtonOpts(
 			ComboButtonOpts.ButtonOpts(
 				ButtonOpts.Image(&ButtonImage{
-					Idle: newNineSliceEmpty(t),
+					Idle:    newNineSliceEmpty(t),
+					Pressed: newNineSliceEmpty(t),
 				}),
 				ButtonOpts.TextAndImage("", loadFont(t), &ButtonImageImage{
 					Idle:     newImageEmpty(t),
@@ -89,7 +86,11 @@ func newSelectComboButton(t *testing.T, opts ...SelectComboButtonOpt) *SelectCom
 					Disabled: color.Transparent,
 				}),
 			),
-			ComboButtonOpts.Content(newButton(t))),
+			ComboButtonOpts.Content(newButton(t)),
+		),
+		SelectComboButtonOpts.EntryLabelFunc(func(e interface{}) string {
+			return "label " + e.(string)
+		}),
 	)...)
 
 	event.ExecuteDeferred()

--- a/widget/slider_test.go
+++ b/widget/slider_test.go
@@ -25,7 +25,8 @@ func newSlider(t *testing.T, opts ...SliderOpt) *Slider {
 	s := NewSlider(append(opts, SliderOpts.Images(&SliderTrackImage{
 		Idle: newNineSliceEmpty(t),
 	}, &ButtonImage{
-		Idle: newNineSliceEmpty(t),
+		Idle:    newNineSliceEmpty(t),
+		Pressed: newNineSliceEmpty(t),
 	}))...)
 	event.ExecuteDeferred()
 	render(s, t)

--- a/widget/tabbook_test.go
+++ b/widget/tabbook_test.go
@@ -110,7 +110,8 @@ func newTabBook(t *testing.T, opts ...TabBookOpt) *TabBook {
 
 	tb := NewTabBook(append(opts, []TabBookOpt{
 		TabBookOpts.TabButtonImage(&ButtonImage{
-			Idle: newNineSliceEmpty(t),
+			Idle:    newNineSliceEmpty(t),
+			Pressed: newNineSliceEmpty(t),
 		}),
 		TabBookOpts.TabButtonText(loadFont(t), &ButtonTextColor{
 			Idle:     color.Transparent,


### PR DESCRIPTION
Revert to default cursor management if set to nil.
If no cursor image is found use the standard default cursors.
Added Cursor_None to hide the cursor.
Fix UTs