### PR TITLE
Pass Container's rect down when calling RequestRelayout.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,6 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Launch Playground",
-			"type": "go",
-			"request": "launch",
-			"mode": "debug",
-			"program": "${workspaceFolder}/_examples/play",
-			"cwd": "${workspaceFolder}/_examples/play",
-			"env": {},
-			"args": []
-		},
-		{
 			"name": "Launch Hello World",
 			"type": "go",
 			"request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,16 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
+			"name": "Launch Playground",
+			"type": "go",
+			"request": "launch",
+			"mode": "debug",
+			"program": "${workspaceFolder}/_examples/play",
+			"cwd": "${workspaceFolder}/_examples/play",
+			"env": {},
+			"args": []
+		},
+		{
 			"name": "Launch Hello World",
 			"type": "go",
 			"request": "launch",

--- a/_examples/demo/main.go
+++ b/_examples/demo/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 
+	img "image"
 	"image/color"
 	_ "image/png"
 
@@ -226,12 +227,10 @@ func demoContainer(res *uiResources, ui func() *ebitenui.UI) widget.PreferredSiz
 func newPageContainer(res *uiResources) *pageContainer {
 	c := widget.NewContainer(
 		widget.ContainerOpts.BackgroundImage(res.panel.image),
-		widget.ContainerOpts.Layout(widget.NewGridLayout(
-			widget.GridLayoutOpts.Columns(1),
-			widget.GridLayoutOpts.Padding(res.panel.padding),
-			widget.GridLayoutOpts.Spacing(0, 15),
-			widget.GridLayoutOpts.Stretch([]bool{true}, []bool{false, true}),
-		)),
+		widget.ContainerOpts.Layout(widget.NewRowLayout(
+			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+			widget.RowLayoutOpts.Padding(res.panel.padding),
+			widget.RowLayoutOpts.Spacing(15))),
 	)
 
 	titleText := widget.NewText(
@@ -258,7 +257,7 @@ func newPageContainer(res *uiResources) *pageContainer {
 func (p *pageContainer) setPage(page *page) {
 	p.titleText.Label = page.title
 	p.flipBook.SetPage(page.content)
-	p.flipBook.RequestRelayout(p.flipBook.GetWidget().Rect)
+	p.flipBook.RequestRelayout(img.Rectangle{})
 }
 
 func newCheckbox(label string, changedHandler widget.CheckboxChangedHandlerFunc, res *uiResources) *widget.LabeledCheckbox {

--- a/_examples/demo/main.go
+++ b/_examples/demo/main.go
@@ -395,7 +395,7 @@ func (g *game) Draw(screen *ebiten.Image) {
 
 		}
 		if dd, ok := p.GetWidget().CustomData.(widget.DebugData); ok {
-			ebitenutil.DebugPrintAt(screen, dd.Message, dd.X, dd.Y)
+			ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%s %s", dd.Name, dd.Message), dd.X, dd.Y)
 		}
 	}
 	dk(g.ui.Container)

--- a/_examples/demo/main.go
+++ b/_examples/demo/main.go
@@ -386,7 +386,19 @@ func (g *game) Update() error {
 
 func (g *game) Draw(screen *ebiten.Image) {
 	g.ui.Draw(screen)
+	var dk func(p widget.PreferredSizeLocateableWidget)
+	dk = func(p widget.PreferredSizeLocateableWidget) {
+		if pc, ok := p.(*widget.Container); ok {
+			for _, c := range pc.Children() {
+				dk(c)
+			}
 
+		}
+		if dd, ok := p.GetWidget().CustomData.(widget.DebugData); ok {
+			ebitenutil.DebugPrintAt(screen, dd.Message, dd.X, dd.Y)
+		}
+	}
+	dk(g.ui.Container)
 	x, y := ebiten.CursorPosition()
 	ebitenutil.DebugPrint(screen, fmt.Sprintf("FPS: %f CUR: %d,%d", ebiten.ActualFPS(), x, y))
 }

--- a/_examples/demo/main.go
+++ b/_examples/demo/main.go
@@ -167,6 +167,7 @@ func demoContainer(res *uiResources, ui func() *ebitenui.UI) widget.PreferredSiz
 		)))
 
 	pages := []interface{}{
+		scrollPage(res),
 		buttonPage(res),
 		checkboxPage(res),
 		listPage(res),
@@ -225,10 +226,12 @@ func demoContainer(res *uiResources, ui func() *ebitenui.UI) widget.PreferredSiz
 func newPageContainer(res *uiResources) *pageContainer {
 	c := widget.NewContainer(
 		widget.ContainerOpts.BackgroundImage(res.panel.image),
-		widget.ContainerOpts.Layout(widget.NewRowLayout(
-			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
-			widget.RowLayoutOpts.Padding(res.panel.padding),
-			widget.RowLayoutOpts.Spacing(15))),
+		widget.ContainerOpts.Layout(widget.NewGridLayout(
+			widget.GridLayoutOpts.Columns(1),
+			widget.GridLayoutOpts.Padding(res.panel.padding),
+			widget.GridLayoutOpts.Spacing(0, 15),
+			widget.GridLayoutOpts.Stretch([]bool{true}, []bool{false, true}),
+		)),
 	)
 
 	titleText := widget.NewText(
@@ -255,7 +258,7 @@ func newPageContainer(res *uiResources) *pageContainer {
 func (p *pageContainer) setPage(page *page) {
 	p.titleText.Label = page.title
 	p.flipBook.SetPage(page.content)
-	p.flipBook.RequestRelayout()
+	p.flipBook.RequestRelayout(p.flipBook.GetWidget().Rect)
 }
 
 func newCheckbox(label string, changedHandler widget.CheckboxChangedHandlerFunc, res *uiResources) *widget.LabeledCheckbox {
@@ -384,5 +387,6 @@ func (g *game) Update() error {
 func (g *game) Draw(screen *ebiten.Image) {
 	g.ui.Draw(screen)
 
-	ebitenutil.DebugPrint(screen, fmt.Sprintf("FPS: %f", ebiten.ActualFPS()))
+	x, y := ebiten.CursorPosition()
+	ebitenutil.DebugPrint(screen, fmt.Sprintf("FPS: %f CUR: %d,%d", ebiten.ActualFPS(), x, y))
 }

--- a/_examples/demo/page.go
+++ b/_examples/demo/page.go
@@ -267,26 +267,12 @@ func scrollPage(res *uiResources) *page {
 }
 
 func listPage(res *uiResources) *page {
-	c := widget.NewContainer(
-		widget.ContainerOpts.WidgetOpts(
-			widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
-				StretchHorizontal: true,
-				StretchVertical:   true,
-			}),
-			widget.WidgetOpts.DebugData("lp"),
-		),
-		widget.ContainerOpts.BackgroundImage(res.panel.image),
-		widget.ContainerOpts.Layout(widget.NewGridLayout(
-			widget.GridLayoutOpts.Columns(1),
-			widget.GridLayoutOpts.Padding(res.panel.padding),
-			widget.GridLayoutOpts.Spacing(0, 15),
-			widget.GridLayoutOpts.Stretch([]bool{true}, []bool{true, false, false}),
-		)),
-	)
+	c := newPageContentContainer()
 
 	listsContainer := widget.NewContainer(
 		widget.ContainerOpts.WidgetOpts(widget.WidgetOpts.LayoutData(widget.RowLayoutData{
 			Stretch: true,
+			Shrink:  true,
 		})),
 		widget.ContainerOpts.Layout(widget.NewGridLayout(
 			widget.GridLayoutOpts.Columns(3),

--- a/_examples/demo/page.go
+++ b/_examples/demo/page.go
@@ -126,6 +126,11 @@ func scrollPage(res *uiResources) *page {
 	rootContainer := widget.NewContainer(
 		// the container will use a plain color as its background
 		widget.ContainerOpts.BackgroundImage(img.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff})),
+		widget.ContainerOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
+				StretchVertical: true,
+			}),
+		),
 
 		// the container will use an grid layout to layout its ScrollableContainer and Slider
 		widget.ContainerOpts.Layout(widget.NewGridLayout(
@@ -263,6 +268,13 @@ func scrollPage(res *uiResources) *page {
 
 func listPage(res *uiResources) *page {
 	c := widget.NewContainer(
+		widget.ContainerOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
+				StretchHorizontal: true,
+				StretchVertical:   true,
+			}),
+			widget.WidgetOpts.DebugData("lp"),
+		),
 		widget.ContainerOpts.BackgroundImage(res.panel.image),
 		widget.ContainerOpts.Layout(widget.NewGridLayout(
 			widget.GridLayoutOpts.Columns(1),

--- a/_examples/demo/page.go
+++ b/_examples/demo/page.go
@@ -3,9 +3,12 @@ package main
 import (
 	"fmt"
 	"image"
+	"image/color"
+	"math"
 	"time"
 
 	"github.com/ebitenui/ebitenui"
+	img "github.com/ebitenui/ebitenui/image"
 	"github.com/ebitenui/ebitenui/input"
 	"github.com/ebitenui/ebitenui/widget"
 )
@@ -106,8 +109,168 @@ func checkboxPage(res *uiResources) *page {
 	}
 }
 
+func scrollPage(res *uiResources) *page {
+	innerContainer3 := widget.NewContainer(
+		widget.ContainerOpts.BackgroundImage(img.NewNineSliceColor(color.NRGBA{0, 0, 255, 255})),
+		widget.ContainerOpts.WidgetOpts(
+			//The widget in this cell has a MaxHeight and MaxWidth less than the
+			//Size of the grid cell so it will use the Position fields below to
+			//Determine where the widget should be displayed within that grid cell.
+			widget.WidgetOpts.LayoutData(widget.GridLayoutData{
+				HorizontalPosition: widget.GridLayoutPositionCenter,
+				VerticalPosition:   widget.GridLayoutPositionCenter,
+			}),
+		),
+	)
+
+	rootContainer := widget.NewContainer(
+		// the container will use a plain color as its background
+		widget.ContainerOpts.BackgroundImage(img.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff})),
+
+		// the container will use an grid layout to layout its ScrollableContainer and Slider
+		widget.ContainerOpts.Layout(widget.NewGridLayout(
+			widget.GridLayoutOpts.Columns(2),
+			widget.GridLayoutOpts.Spacing(2, 0),
+			widget.GridLayoutOpts.Stretch([]bool{true, false}, []bool{true}),
+		)),
+	)
+
+	//Create the container with the content that should be scrolled
+	/*
+		content := widget.NewContainer(widget.ContainerOpts.Layout(widget.NewRowLayout(
+			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+			widget.RowLayoutOpts.Spacing(20),
+		)))
+	*/
+	content := widget.NewContainer(widget.ContainerOpts.Layout(widget.NewGridLayout(
+		widget.GridLayoutOpts.Columns(1),
+		widget.GridLayoutOpts.Spacing(0, 20),
+	)))
+
+	//Add 20 buttons to the scrollable content container
+	for x := 0; x < 20; x++ {
+		//Capture x for use in callback
+		x := x
+		// construct a button
+		button := widget.NewButton(
+			// set general widget options
+			widget.ButtonOpts.WidgetOpts(
+				// instruct the container's anchor layout to center the button both horizontally and vertically
+				widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+					Position: widget.RowLayoutPositionCenter,
+				}),
+			),
+
+			// specify the images to use
+			widget.ButtonOpts.Image(res.list.handle),
+
+			// specify the button's text, the font face, and the color
+			widget.ButtonOpts.Text(fmt.Sprintf("Hello, World! - %d", x), res.list.face, &widget.ButtonTextColor{
+				Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+			}),
+
+			// specify that the button's text needs some padding for correct display
+			widget.ButtonOpts.TextPadding(widget.Insets{
+				Left:   30,
+				Right:  30,
+				Top:    5,
+				Bottom: 5,
+			}),
+
+			// add a handler that reacts to clicking the button
+			widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+				println(fmt.Sprintf("Button %d Clicked!", x))
+			}),
+		)
+
+		// add the button as a child of the container
+		content.AddChild(button)
+	}
+
+	//Create the new ScrollContainer object
+	scrollContainer := widget.NewScrollContainer(
+		//Set the content that will be scrolled
+		widget.ScrollContainerOpts.Content(content),
+		//Tell the container to stretch the content width to match available space
+		widget.ScrollContainerOpts.StretchContentWidth(),
+		//Set the background images for the scrollable container
+		widget.ScrollContainerOpts.Image(&widget.ScrollContainerImage{
+			Idle: img.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff}),
+			Mask: img.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff}),
+		}),
+		widget.ScrollContainerOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.GridLayoutData{
+				HorizontalPosition: widget.GridLayoutPositionCenter,
+				VerticalPosition:   widget.GridLayoutPositionCenter,
+			}),
+		),
+	)
+	//Add the scrollable container to the left side of the window
+	rootContainer.AddChild(scrollContainer)
+
+	//Create a function to return the page size used by the slider
+	pageSizeFunc := func() int {
+		return int(math.Round(float64(scrollContainer.ViewRect().Dy()) / float64(content.GetWidget().Rect.Dy()) * 1000))
+	}
+	//Create a vertical Slider bar to control the ScrollableContainer
+	vSlider := widget.NewSlider(
+		widget.SliderOpts.Direction(widget.DirectionVertical),
+		widget.SliderOpts.MinMax(0, 1000),
+		widget.SliderOpts.PageSizeFunc(pageSizeFunc),
+		//On change update scroll location based on the Slider's value
+		widget.SliderOpts.ChangedHandler(func(args *widget.SliderChangedEventArgs) {
+			scrollContainer.ScrollTop = float64(args.Slider.Current) / 1000
+		}),
+		widget.SliderOpts.Images(
+			// Set the track images
+			&widget.SliderTrackImage{
+				Idle:  img.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
+				Hover: img.NewNineSliceColor(color.NRGBA{100, 100, 100, 255}),
+			},
+			// Set the handle images
+			&widget.ButtonImage{
+				Idle:    img.NewNineSliceColor(color.NRGBA{255, 100, 100, 255}),
+				Hover:   img.NewNineSliceColor(color.NRGBA{255, 100, 100, 255}),
+				Pressed: img.NewNineSliceColor(color.NRGBA{255, 100, 100, 255}),
+			},
+		),
+		widget.SliderOpts.WidgetOpts(
+			widget.WidgetOpts.LayoutData(widget.GridLayoutData{
+				HorizontalPosition: widget.GridLayoutPositionCenter,
+				VerticalPosition:   widget.GridLayoutPositionCenter,
+			}),
+		),
+	)
+	//Set the slider's position if the scrollContainer is scrolled by other means than the slider
+	scrollContainer.GetWidget().ScrolledEvent.AddHandler(func(args interface{}) {
+		a := args.(*widget.WidgetScrolledEventArgs)
+		p := pageSizeFunc() / 3
+		if p < 1 {
+			p = 1
+		}
+		vSlider.Current -= int(math.Round(a.Y * float64(p)))
+	})
+
+	//Add the slider to the second slot in the root container
+	rootContainer.AddChild(vSlider)
+
+	innerContainer3.AddChild(rootContainer)
+	return &page{
+		title:   "AaaScroll",
+		content: rootContainer,
+	}
+}
+
 func listPage(res *uiResources) *page {
-	c := newPageContentContainer()
+	c := widget.NewContainer(
+		widget.ContainerOpts.BackgroundImage(res.panel.image),
+		widget.ContainerOpts.Layout(widget.NewGridLayout(
+			widget.GridLayoutOpts.Columns(1),
+			widget.GridLayoutOpts.Padding(res.panel.padding),
+			widget.GridLayoutOpts.Spacing(0, 15),
+			widget.GridLayoutOpts.Stretch([]bool{true}, []bool{true, false, false}),
+		)),
+	)
 
 	listsContainer := widget.NewContainer(
 		widget.ContainerOpts.WidgetOpts(widget.WidgetOpts.LayoutData(widget.RowLayoutData{
@@ -119,10 +282,9 @@ func listPage(res *uiResources) *page {
 			widget.GridLayoutOpts.Spacing(10, 0))))
 	c.AddChild(listsContainer)
 
-	entries1 := []interface{}{"One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"}
-	list1 := newList(entries1, res, widget.WidgetOpts.LayoutData(widget.GridLayoutData{
-		MaxHeight: 220,
-	}))
+	entries1 := []interface{}{"One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten",
+		"Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen", "Sixteen", "Seventeen", "Eighteen", "Nineteen", "Twenty"}
+	list1 := newList(entries1, res, widget.WidgetOpts.LayoutData(widget.GridLayoutData{}))
 	listsContainer.AddChild(list1)
 
 	buttonsContainer := widget.NewContainer(
@@ -146,9 +308,7 @@ func listPage(res *uiResources) *page {
 	}
 
 	entries2 := []interface{}{"Eleven", "Twelve", "Thirteen", "Fourteen", "Fifteen", "Sixteen", "Seventeen", "Eighteen", "Nineteen", "Twenty"}
-	list2 := newList(entries2, res, widget.WidgetOpts.LayoutData(widget.GridLayoutData{
-		MaxHeight: 220,
-	}))
+	list2 := newList(entries2, res, widget.WidgetOpts.LayoutData(widget.GridLayoutData{}))
 	listsContainer.AddChild(list2)
 
 	c.AddChild(newSeparator(res, widget.RowLayoutData{
@@ -283,7 +443,7 @@ func comboButtonPage(res *uiResources) *page {
 			return fmt.Sprintf("Entry %d", e.(int))
 		},
 		func(args *widget.ListComboButtonEntrySelectedEventArgs) {
-			c.RequestRelayout()
+			c.RequestRelayout(c.GetWidget().Rect)
 		},
 		res)
 	c.AddChild(cb)
@@ -1042,7 +1202,7 @@ func anchorLayoutPage(res *uiResources) *page {
 			ald := sp.GetWidget().LayoutData.(widget.AnchorLayoutData)
 			ald.HorizontalPosition = widget.AnchorLayoutPosition(indexCheckbox(hCBs, args.Active))
 			sp.GetWidget().LayoutData = ald
-			p.RequestRelayout()
+			p.RequestRelayout(p.GetWidget().Rect)
 		}),
 	)
 
@@ -1073,7 +1233,7 @@ func anchorLayoutPage(res *uiResources) *page {
 			ald := sp.GetWidget().LayoutData.(widget.AnchorLayoutData)
 			ald.VerticalPosition = widget.AnchorLayoutPosition(indexCheckbox(vCBs, args.Active))
 			sp.GetWidget().LayoutData = ald
-			p.RequestRelayout()
+			p.RequestRelayout(p.GetWidget().Rect)
 		}),
 	)
 
@@ -1091,7 +1251,7 @@ func anchorLayoutPage(res *uiResources) *page {
 		ald := sp.GetWidget().LayoutData.(widget.AnchorLayoutData)
 		ald.StretchHorizontal = args.State == widget.WidgetChecked
 		sp.GetWidget().LayoutData = ald
-		p.RequestRelayout()
+		p.RequestRelayout(p.GetWidget().Rect)
 
 		hPosC.GetWidget().Disabled = args.State == widget.WidgetChecked
 	}, res)
@@ -1101,7 +1261,7 @@ func anchorLayoutPage(res *uiResources) *page {
 		ald := sp.GetWidget().LayoutData.(widget.AnchorLayoutData)
 		ald.StretchVertical = args.State == widget.WidgetChecked
 		sp.GetWidget().LayoutData = ald
-		p.RequestRelayout()
+		p.RequestRelayout(p.GetWidget().Rect)
 
 		vPosC.GetWidget().Disabled = args.State == widget.WidgetChecked
 	}, res)

--- a/widget/anchorlayout.go
+++ b/widget/anchorlayout.go
@@ -85,7 +85,20 @@ func (a *AnchorLayout) PreferredSize(widgets []PreferredSizeLocateableWidget) (i
 }
 
 // Layout implements Layouter.
+func (a *AnchorLayout) CalcLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) []image.Rectangle {
+	res := make([]image.Rectangle, 0)
+	a.doLayout(widgets, rect, func(pslw PreferredSizeLocateableWidget, r image.Rectangle) {
+		res = append(res, r)
+	})
+	return res
+}
+
 func (a *AnchorLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) {
+	a.doLayout(widgets, rect, func(pslw PreferredSizeLocateableWidget, r image.Rectangle) {
+		pslw.SetLocation(r)
+	})
+}
+func (a *AnchorLayout) doLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle, locater LocationFunction) {
 	if len(widgets) == 0 {
 		return
 	}
@@ -109,7 +122,7 @@ func (a *AnchorLayout) Layout(widgets []PreferredSizeLocateableWidget, rect imag
 		r = r.Add(image.Point{wx, wy})
 		r = r.Add(wrect.Min)
 
-		widget.SetLocation(r)
+		locater(widget, r)
 	}
 }
 

--- a/widget/anchorlayout.go
+++ b/widget/anchorlayout.go
@@ -128,11 +128,11 @@ func (a *AnchorLayout) doLayout(widgets []PreferredSizeLocateableWidget, rect im
 
 func (a *AnchorLayout) applyLayoutData(ld AnchorLayoutData, wx int, wy int, ww int, wh int, rect image.Rectangle) (int, int, int, int) {
 
-	if ld.StretchHorizontal {
+	if ld.StretchHorizontal || ww > rect.Dx() {
 		ww = rect.Dx()
 	}
 
-	if ld.StretchVertical {
+	if ld.StretchVertical || wh > rect.Dy() {
 		wh = rect.Dy()
 	}
 

--- a/widget/button.go
+++ b/widget/button.go
@@ -476,11 +476,11 @@ func (b *Button) SetLocation(rect img.Rectangle) {
 	b.widget.Rect = rect
 }
 
-func (b *Button) RequestRelayout() {
+func (b *Button) RequestRelayout(rect img.Rectangle) {
 	b.init.Do()
 
 	if b.container != nil {
-		b.container.RequestRelayout()
+		b.container.RequestRelayout(rect)
 	}
 }
 
@@ -499,7 +499,7 @@ func (b *Button) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 		w := b.container.GetWidget()
 		w.Rect = b.widget.Rect
 		w.Disabled = b.widget.Disabled
-		b.container.RequestRelayout()
+		b.container.RequestRelayout(w.Rect)
 	}
 
 	b.widget.Render(screen, def)

--- a/widget/combobutton.go
+++ b/widget/combobutton.go
@@ -86,7 +86,7 @@ func (c *ComboButton) PreferredSize() (int, int) {
 func (c *ComboButton) SetLabel(l string) {
 	c.init.Do()
 	c.button.Text().Label = l
-	c.button.RequestRelayout()
+	c.button.RequestRelayout(c.button.widget.Rect)
 }
 
 func (c *ComboButton) Label() string {
@@ -186,7 +186,7 @@ func (c *ComboButton) relayoutContent() {
 		return
 	}
 
-	r.RequestRelayout()
+	r.RequestRelayout(cr)
 }
 
 func (c *ComboButton) createWidget() {

--- a/widget/container.go
+++ b/widget/container.go
@@ -18,7 +18,6 @@ type Container struct {
 	widgetOpts      []WidgetOpt
 	layout          Layouter
 	layoutDirty     bool
-	layoutHappening bool
 
 	init     *MultiOnce
 	widget   *Widget

--- a/widget/container.go
+++ b/widget/container.go
@@ -3,6 +3,7 @@ package widget
 import (
 	"fmt"
 	img "image"
+	"strconv"
 
 	"github.com/ebitenui/ebitenui/image"
 	"github.com/ebitenui/ebitenui/input"
@@ -169,14 +170,31 @@ func (c *Container) Children() []PreferredSizeLocateableWidget {
 	return c.children
 }
 
+var _id int = 0
+
 func (c *Container) RequestRelayout(rect img.Rectangle) {
 	c.init.Do()
 
-	wasDirty := c.layoutDirty
 	c.layoutDirty = true
-	c.widget.CustomData = DebugData{rect.Min.X, rect.Min.Y, fmt.Sprintf("%d,%d", rect.Max.X, rect.Max.Y)}
+	var dd *DebugData
+	if d, ok := c.widget.CustomData.(DebugData); ok {
+		dd = &d
+	} else {
+		if c.widget.CustomData == nil {
+			dd = &DebugData{Name: strconv.Itoa(_id + 1)}
+		}
+		_id += 1
+	}
+	if dd != nil {
+		dd.X = rect.Min.X
+		dd.Y = rect.Min.Y
+		dd.Message = fmt.Sprintf("%d,%d", rect.Max.X, rect.Max.Y)
+		c.widget.CustomData = *dd
+	}
+
+	c.widget.CustomData = *dd
 	crects := make([]img.Rectangle, 0)
-	if !wasDirty && !rect.Empty() {
+	if !rect.Empty() {
 		crects = c.doCalcLayout(rect)
 	}
 

--- a/widget/container.go
+++ b/widget/container.go
@@ -103,7 +103,7 @@ func (c *Container) AddChild(child PreferredSizeLocateableWidget) RemoveChildFun
 		a := args.(*WidgetDragAndDropEventArgs)
 		c.GetWidget().FireDragAndDropEvent(a.Window, a.Show, a.DnD)
 	})
-	c.RequestRelayout()
+	c.RequestRelayout(c.widget.Rect)
 
 	return func() {
 		c.RemoveChild(child)
@@ -138,7 +138,7 @@ func (c *Container) RemoveChild(child PreferredSizeLocateableWidget) {
 	if child.GetWidget().ContextMenuWindow != nil {
 		child.GetWidget().ContextMenuWindow.Close()
 	}
-	c.RequestRelayout()
+	c.RequestRelayout(c.widget.Rect)
 }
 
 func (c *Container) RemoveChildren() {
@@ -160,21 +160,21 @@ func (c *Container) RemoveChildren() {
 	}
 	c.children = nil
 
-	c.RequestRelayout()
+	c.RequestRelayout(c.widget.Rect)
 }
 
 func (c *Container) Children() []PreferredSizeLocateableWidget {
 	return c.children
 }
 
-func (c *Container) RequestRelayout() {
+func (c *Container) RequestRelayout(rect img.Rectangle) {
 	c.init.Do()
 
 	c.layoutDirty = true
 
 	for _, ch := range c.children {
 		if r, ok := ch.(Relayoutable); ok {
-			r.RequestRelayout()
+			r.RequestRelayout(rect)
 		}
 	}
 }
@@ -203,7 +203,7 @@ func (c *Container) PreferredSize() (int, int) {
 func (c *Container) SetLocation(rect img.Rectangle) {
 	c.init.Do()
 	c.widget.Rect = rect
-	c.RequestRelayout()
+	c.RequestRelayout(rect)
 }
 
 func (c *Container) Render(screen *ebiten.Image, def DeferredRenderFunc) {

--- a/widget/flipbook.go
+++ b/widget/flipbook.go
@@ -75,9 +75,9 @@ func (f *FlipBook) SetLocation(rect img.Rectangle) {
 }
 
 // RequestRelayout implements Relayoutable.
-func (f *FlipBook) RequestRelayout() {
+func (f *FlipBook) RequestRelayout(rect img.Rectangle) {
 	f.init.Do()
-	f.container.RequestRelayout()
+	f.container.RequestRelayout(rect)
 }
 
 // SetupInputLayer implements InputLayerer.

--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -106,7 +106,19 @@ func (g *GridLayout) PreferredSize(widgets []PreferredSizeLocateableWidget) (int
 }
 
 // Layout implements Layouter.
+func (g *GridLayout) CalcLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) []image.Rectangle {
+	res := make([]image.Rectangle, 0)
+	g.doLayout(widgets, rect, func(pslw PreferredSizeLocateableWidget, r image.Rectangle) {
+		res = append(res, r)
+	})
+	return res
+}
 func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) {
+	g.doLayout(widgets, rect, func(pslw PreferredSizeLocateableWidget, r image.Rectangle) {
+		pslw.SetLocation(r)
+	})
+}
+func (g *GridLayout) doLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle, locater LocationFunction) {
 	rect = g.padding.Apply(rect)
 
 	colWidths, rowHeights := g.preferredColumnWidthsAndRowHeights(widgets)
@@ -146,7 +158,7 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 			wx, wy, ww, wh = g.applyLayoutData(gld, wx, wy, ww, wh, x, y, cw, ch)
 		}
 
-		w.SetLocation(image.Rect(rect.Min.X+wx, rect.Min.Y+wy, rect.Min.X+wx+ww, rect.Min.Y+wy+wh))
+		locater(w, image.Rect(rect.Min.X+wx, rect.Min.Y+wy, rect.Min.X+wx+ww, rect.Min.Y+wy+wh))
 
 		c++
 		x += cw + g.columnSpacing

--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -48,7 +48,7 @@ const (
 	// GridLayoutPositionStart is the center anchoring position.
 	GridLayoutPositionCenter
 
-	// GridLayoutPositionStart is the anchoring position for "right" (in the horizontal direction) or "bottom" (in the vertical direction.)
+	// GridLayoutPositionEnd is the anchoring position for "right" (in the horizontal direction) or "bottom" (in the vertical direction.)
 	GridLayoutPositionEnd
 )
 
@@ -255,7 +255,7 @@ func (g *GridLayout) applyLayoutData(ld GridLayoutData, wx int, wy int, ww int, 
 
 	switch ld.VerticalPosition {
 	case GridLayoutPositionCenter:
-		wy = x + (ch-wh)/2
+		wy = y + (ch-wh)/2
 	case GridLayoutPositionEnd:
 		wy = y + ch - wh
 	}

--- a/widget/layout.go
+++ b/widget/layout.go
@@ -4,9 +4,11 @@ import (
 	"image"
 )
 
+type LocationFunction func(PreferredSizeLocateableWidget, image.Rectangle)
 type Layouter interface {
 	PreferredSize(widgets []PreferredSizeLocateableWidget) (int, int)
 	Layout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle)
+	CalcLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) []image.Rectangle
 }
 
 type Relayoutable interface {

--- a/widget/layout.go
+++ b/widget/layout.go
@@ -10,7 +10,7 @@ type Layouter interface {
 }
 
 type Relayoutable interface {
-	RequestRelayout()
+	RequestRelayout(rect image.Rectangle)
 }
 
 type Locateable interface {

--- a/widget/list.go
+++ b/widget/list.go
@@ -277,9 +277,9 @@ func (l *List) SetLocation(rect img.Rectangle) {
 	l.container.GetWidget().Rect = rect
 }
 
-func (l *List) RequestRelayout() {
+func (l *List) RequestRelayout(rect img.Rectangle) {
 	l.init.Do()
-	l.container.RequestRelayout()
+	l.container.RequestRelayout(rect)
 }
 
 func (l *List) SetupInputLayer(def input.DeferredSetupInputLayerFunc) {
@@ -431,11 +431,10 @@ func (l *List) createWidget() {
 				GridLayoutOpts.Stretch([]bool{true, false}, []bool{true, false}),
 				GridLayoutOpts.Spacing(l.controlWidgetSpacing, l.controlWidgetSpacing))))...)
 
-	l.listContent = NewContainer(
-		ContainerOpts.Layout(NewRowLayout(
-			RowLayoutOpts.Direction(DirectionVertical))),
-		ContainerOpts.AutoDisableChildren(),
-	)
+	l.listContent = NewContainer(ContainerOpts.Layout(NewGridLayout(
+		GridLayoutOpts.Columns(1),
+		GridLayoutOpts.Stretch([]bool{true}, []bool{}),
+	)))
 
 	l.buttons = make([]*Button, 0, len(l.entries))
 	for _, e := range l.entries {

--- a/widget/list.go
+++ b/widget/list.go
@@ -446,6 +446,12 @@ func (l *List) createWidget() {
 	}
 
 	l.scrollContainer = NewScrollContainer(append(l.scrollContainerOpts, []ScrollContainerOpt{
+		ScrollContainerOpts.WidgetOpts(
+			WidgetOpts.LayoutData(GridLayoutData{
+				HorizontalPosition: GridLayoutPositionCenter,
+				VerticalPosition:   GridLayoutPositionCenter,
+			}),
+		),
 		ScrollContainerOpts.Content(l.listContent),
 		ScrollContainerOpts.StretchContentWidth(),
 	}...)...)

--- a/widget/list.go
+++ b/widget/list.go
@@ -431,10 +431,11 @@ func (l *List) createWidget() {
 				GridLayoutOpts.Stretch([]bool{true, false}, []bool{true, false}),
 				GridLayoutOpts.Spacing(l.controlWidgetSpacing, l.controlWidgetSpacing))))...)
 
-	l.listContent = NewContainer(ContainerOpts.Layout(NewGridLayout(
-		GridLayoutOpts.Columns(1),
-		GridLayoutOpts.Stretch([]bool{true}, []bool{}),
-	)))
+	l.listContent = NewContainer(
+		ContainerOpts.Layout(NewRowLayout(
+			RowLayoutOpts.Direction(DirectionVertical))),
+		ContainerOpts.AutoDisableChildren(),
+	)
 
 	l.buttons = make([]*Button, 0, len(l.entries))
 	for _, e := range l.entries {
@@ -446,12 +447,6 @@ func (l *List) createWidget() {
 	}
 
 	l.scrollContainer = NewScrollContainer(append(l.scrollContainerOpts, []ScrollContainerOpt{
-		ScrollContainerOpts.WidgetOpts(
-			WidgetOpts.LayoutData(GridLayoutData{
-				HorizontalPosition: GridLayoutPositionCenter,
-				VerticalPosition:   GridLayoutPositionCenter,
-			}),
-		),
 		ScrollContainerOpts.Content(l.listContent),
 		ScrollContainerOpts.StretchContentWidth(),
 	}...)...)

--- a/widget/rowlayout.go
+++ b/widget/rowlayout.go
@@ -93,6 +93,13 @@ func (r *RowLayout) PreferredSize(widgets []PreferredSizeLocateableWidget) (int,
 }
 
 // Layout implements Layouter.
+func (r *RowLayout) CalcLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) []image.Rectangle {
+	res := make([]image.Rectangle, 0)
+	r.layout(widgets, rect, true, func(w PreferredSizeLocateableWidget, wr image.Rectangle) {
+		res = append(res, wr)
+	})
+	return res
+}
 func (r *RowLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) {
 	r.layout(widgets, rect, true, func(w PreferredSizeLocateableWidget, wr image.Rectangle) {
 		w.SetLocation(wr)

--- a/widget/rowlayout.go
+++ b/widget/rowlayout.go
@@ -1,6 +1,9 @@
 package widget
 
-import "image"
+import (
+	"image"
+	img "image"
+)
 
 // RowLayout layouts widgets in either a single row or a single column,
 // optionally stretching them in the other direction.
@@ -31,6 +34,9 @@ type RowLayoutData struct {
 
 	// MaxHeight specifies the maximum height.
 	MaxHeight int
+
+	// Shrink specifies whether to shrink in the primary direction of the layout. Assumes that the Widget can handle it
+	Shrink bool
 }
 
 // RowLayoutPosition is the type used to specify an anchoring position.
@@ -114,13 +120,51 @@ func (r *RowLayout) layout(widgets []PreferredSizeLocateableWidget, rect image.R
 	rect = r.padding.Apply(rect)
 	x, y := 0, 0
 
-	for _, widget := range widgets {
+	// make a pass to see if there is something resizable in case our stuff won't fit
+	// this could be better, but would be a lot more complicated
+	prefs := make([]img.Point, len(widgets))
+	relay := -1
+	tw, th := 0, 0
+	vis := 0
+	for i, widget := range widgets {
+		if widget.GetWidget().Visibility == Visibility_Hide {
+			continue
+		}
+		ww, wh := widget.PreferredSize()
+		prefs[i] = img.Point{ww, wh}
+		vis += 1
+		if relay < 0 {
+			if rld, ok := widget.GetWidget().LayoutData.(RowLayoutData); ok {
+				if rld.Shrink {
+					relay = i
+				}
+			}
+		}
+	}
+	if rect.Dx() > 0 && rect.Dy() > 0 {
+		if r.direction == DirectionHorizontal {
+			tw += ((vis - 1) * r.spacing)
+			if tw > rect.Dx() && relay != -1 {
+				tw -= prefs[relay].X
+				prefs[relay].X = rect.Dx() - tw
+			}
+		} else {
+			th += ((vis - 1) * r.spacing)
+			if th > rect.Dy() && relay != -1 {
+				th -= prefs[relay].Y
+				prefs[relay].Y = rect.Dy() - th
+			}
+
+		}
+	}
+
+	for i, widget := range widgets {
 		if widget.GetWidget().Visibility == Visibility_Hide {
 			continue
 		}
 
 		wx, wy := x, y
-		ww, wh := widget.PreferredSize()
+		ww, wh := prefs[i].X, prefs[i].Y
 
 		ld := widget.GetWidget().LayoutData
 		if rld, ok := ld.(RowLayoutData); ok {
@@ -142,7 +186,7 @@ func (r *RowLayout) layout(widgets []PreferredSizeLocateableWidget, rect image.R
 
 func (r *RowLayout) applyLayoutData(ld RowLayoutData, wx int, wy int, ww int, wh int, usePosition bool, rect image.Rectangle, x int, y int) (int, int, int, int) {
 	if usePosition {
-		ww, wh = r.applyStretch(ld, ww, wh, rect)
+		ww, wh = r.applyStretch(ld, ww, wh, rect, x, y)
 	}
 
 	ww, wh = r.applyMaxSize(ld, ww, wh)
@@ -154,7 +198,7 @@ func (r *RowLayout) applyLayoutData(ld RowLayoutData, wx int, wy int, ww int, wh
 	return wx, wy, ww, wh
 }
 
-func (r *RowLayout) applyStretch(ld RowLayoutData, ww int, wh int, rect image.Rectangle) (int, int) {
+func (r *RowLayout) applyStretch(ld RowLayoutData, ww int, wh int, rect image.Rectangle, x int, y int) (int, int) {
 	if !ld.Stretch {
 		return ww, wh
 	}
@@ -163,6 +207,14 @@ func (r *RowLayout) applyStretch(ld RowLayoutData, ww int, wh int, rect image.Re
 		wh = rect.Dy()
 	} else {
 		ww = rect.Dx()
+	}
+
+	if ww > (rect.Dx() - x) {
+		ww = rect.Dx() - x
+	}
+
+	if wh > (rect.Dy() - y) {
+		wh = rect.Dy() - y
 	}
 
 	return ww, wh

--- a/widget/rowlayout_test.go
+++ b/widget/rowlayout_test.go
@@ -77,6 +77,40 @@ func TestRowLayout_PreferredSize(t *testing.T) {
 	is.Equal(h, expectedHeight)
 }
 
+func TestRowLayout_Stretch(t *testing.T) {
+	is := is.New(t)
+	l := newRowLayout(t,
+		RowLayoutOpts.Padding(Insets{
+			Top:    10,
+			Left:   20,
+			Right:  30,
+			Bottom: 40,
+		}),
+		RowLayoutOpts.Spacing(7),
+	)
+	widgets := []PreferredSizeLocateableWidget{
+		newSimpleWidget(10, 10, nil),
+		newSimpleWidget(10, 10, RowLayoutData{
+			Position: RowLayoutPositionCenter,
+			Stretch:  true,
+		}),
+		newSimpleWidget(10, 10, RowLayoutData{
+			Position: RowLayoutPositionEnd,
+		}),
+	}
+	l.Layout(widgets, image.Rect(25, 25, 200, 200))
+
+	expected := []image.Rectangle{
+		image.Rect(45, 35, 55, 45),
+		image.Rect(62, 35, 72, 160),
+		image.Rect(79, 150, 89, 160),
+	}
+
+	for i, r := range expected {
+		is.Equal(widgets[i].GetWidget().Rect, r)
+	}
+}
+
 func TestRowLayout_Layout(t *testing.T) {
 	is := is.New(t)
 

--- a/widget/stackedlayout.go
+++ b/widget/stackedlayout.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"image"
+	img "image"
 )
 
 // StackedLayout lays out multiple widgets stacked on top of each other in the order they are added as children
@@ -70,12 +71,25 @@ func (a *StackedLayout) PreferredSize(widgets []PreferredSizeLocateableWidget) (
 }
 
 // Layout implements Layouter.
+func (a *StackedLayout) CalcLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) []img.Rectangle {
+	res := make([]img.Rectangle, 0)
+	a.doLayout(widgets, rect, func(w PreferredSizeLocateableWidget, rect image.Rectangle) {
+		res = append(res, rect)
+	})
+	return res
+}
+
 func (a *StackedLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle) {
+	a.doLayout(widgets, rect, func(w PreferredSizeLocateableWidget, rect image.Rectangle) {
+		w.SetLocation(rect)
+	})
+}
+func (a *StackedLayout) doLayout(widgets []PreferredSizeLocateableWidget, rect image.Rectangle, locater LocationFunction) {
 	if len(widgets) == 0 {
 		return
 	}
 	rect = a.padding.Apply(rect)
 	for idx := range widgets {
-		widgets[idx].SetLocation(rect)
+		locater(widgets[idx], rect)
 	}
 }

--- a/widget/tabbook.go
+++ b/widget/tabbook.go
@@ -193,9 +193,9 @@ func (t *TabBook) SetLocation(rect image.Rectangle) {
 	t.container.SetLocation(rect)
 }
 
-func (t *TabBook) RequestRelayout() {
+func (t *TabBook) RequestRelayout(rect image.Rectangle) {
 	t.init.Do()
-	t.container.RequestRelayout()
+	t.container.RequestRelayout(rect)
 }
 
 func (t *TabBook) SetupInputLayer(def input.DeferredSetupInputLayerFunc) {

--- a/widget/textarea.go
+++ b/widget/textarea.go
@@ -210,9 +210,9 @@ func (l *TextArea) SetLocation(rect img.Rectangle) {
 	l.container.GetWidget().Rect = rect
 }
 
-func (l *TextArea) RequestRelayout() {
+func (l *TextArea) RequestRelayout(rect img.Rectangle) {
 	l.init.Do()
-	l.container.RequestRelayout()
+	l.container.RequestRelayout(rect)
 }
 
 func (l *TextArea) SetupInputLayer(def input.DeferredSetupInputLayerFunc) {

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -12,6 +12,7 @@ import (
 type DebugData struct {
 	X, Y    int
 	Message string
+	Name    string
 }
 
 // A Widget is an abstraction of a user interface widget, such as a button. Actual widget implementations
@@ -283,6 +284,22 @@ func NewWidget(opts ...WidgetOpt) *Widget {
 	}
 
 	return w
+}
+
+// WithLayoutData configures a Widget with layout data ld.
+func (o WidgetOptions) DebugData(name string) WidgetOpt {
+	return func(w *Widget) {
+		cd := w.CustomData
+		if cd != nil {
+			if dd, ok := cd.(DebugData); ok {
+				dd.Name = name
+			}
+		} else {
+			w.CustomData = DebugData{
+				Name: name,
+			}
+		}
+	}
 }
 
 // WithLayoutData configures a Widget with layout data ld.

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -9,6 +9,11 @@ import (
 	"github.com/hajimehoshi/ebiten/v2"
 )
 
+type DebugData struct {
+	X, Y    int
+	Message string
+}
+
 // A Widget is an abstraction of a user interface widget, such as a button. Actual widget implementations
 // "have" a Widget in their internal structure.
 type Widget struct {

--- a/widget/window.go
+++ b/widget/window.go
@@ -232,8 +232,8 @@ func (w *Window) GetCloseFunction() RemoveWindowFunc {
 }
 
 // Typically used internally
-func (w *Window) RequestRelayout() {
-	w.container.RequestRelayout()
+func (w *Window) RequestRelayout(rect image.Rectangle) {
+	w.container.RequestRelayout(rect)
 }
 
 // Typically used internally


### PR DESCRIPTION
This allow Relayoutable children to know more about their bounds so that they can better control their layout when rendering. Update ScrollContainer to make use of it. GridsLayout can be nested well enough that this additional information and swapping some containers from a RowLayout(Vertical) to a GridLayout(Col=1) allows some improvement without fully implementing a solution that would require significant more work.

 Included updated demo to demonstrate it working which also required messing with some List internals.