### PR TITLE
add move event to Widget and Button

### DIFF
--- a/_examples/widget_demos/button/main.go
+++ b/_examples/widget_demos/button/main.go
@@ -77,7 +77,7 @@ func main() {
 
 		// add a handler that reacts to moving the cursor on the button
 		widget.ButtonOpts.CursorMovedHandler(func(args *widget.ButtonHoverEventArgs) {
-			println("cursor moved on button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY)
+			println("cursor moved on button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY, "diffX =", args.DiffX, "diffY =", args.DiffY)
 		}),
 
 		// add a handler that reacts to exiting the button with the cursor

--- a/_examples/widget_demos/button/main.go
+++ b/_examples/widget_demos/button/main.go
@@ -70,6 +70,21 @@ func main() {
 			println("button clicked")
 		}),
 
+		// add a handler that reacts to entering the button with the cursor
+		widget.ButtonOpts.CursorEnteredHandler(func(args *widget.ButtonHoverEventArgs) {
+			println("cursor entered button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY)
+		}),
+
+		// add a handler that reacts to moving the cursor on the button
+		widget.ButtonOpts.CursorMovedHandler(func(args *widget.ButtonHoverEventArgs) {
+			println("cursor moved on button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY)
+		}),
+
+		// add a handler that reacts to exiting the button with the cursor
+		widget.ButtonOpts.CursorExitedHandler(func(args *widget.ButtonHoverEventArgs) {
+			println("cursor exited button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY)
+		}),
+
 		// Indicate that this button should not be submitted when enter or space are pressed
 		// widget.ButtonOpts.DisableDefaultKeys(),
 	)

--- a/widget/button.go
+++ b/widget/button.go
@@ -101,6 +101,8 @@ type ButtonHoverEventArgs struct {
 	Entered bool
 	OffsetX int
 	OffsetY int
+	DiffX   int
+	DiffY   int
 }
 
 type ButtonChangedEventArgs struct {
@@ -667,6 +669,8 @@ func (b *Button) createWidget() {
 				Entered: true,
 				OffsetX: args.OffsetX,
 				OffsetY: args.OffsetY,
+				DiffX:   0,
+				DiffY:   0,
 			})
 		}),
 
@@ -679,6 +683,8 @@ func (b *Button) createWidget() {
 				Entered: false,
 				OffsetX: args.OffsetX,
 				OffsetY: args.OffsetY,
+				DiffX:   args.DiffX,
+				DiffY:   args.DiffY,
 			})
 		}),
 
@@ -689,6 +695,8 @@ func (b *Button) createWidget() {
 				Entered: false,
 				OffsetX: args.OffsetX,
 				OffsetY: args.OffsetY,
+				DiffX:   0,
+				DiffY:   0,
 			})
 		}),
 

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -172,13 +172,18 @@ type WidgetCursorEnterEventArgs struct { //nolint:golint
 // WidgetCursorMoveEventArgs are the arguments for cursor move events.
 type WidgetCursorMoveEventArgs struct { //nolint:golint
 	Widget *Widget
-	Button ebiten.MouseButton
 
 	// OffsetX is the x offset relative to the widget's Rect.
 	OffsetX int
 
 	// OffsetY is the y offset relative to the widget's Rect.
 	OffsetY int
+
+	// DiffX is the x change to the old mouse cursor position.
+	DiffX int
+
+	// DiffY is the y change to the old mouse cursor position.
+	DiffY int
 }
 
 // WidgetCursorExitEventArgs are the arguments for cursor exit events.
@@ -503,21 +508,16 @@ func (w *Widget) fireEvents() {
 	}
 
 	if entered && w.lastUpdateCursorPosition != p {
-		w.lastUpdateCursorPosition = p
-
-		var mouseButton ebiten.MouseButton
-		if input.MouseButtonPressedLayer(ebiten.MouseButtonLeft, layer) {
-			mouseButton = ebiten.MouseButtonLeft
-		} else if input.MouseButtonPressedLayer(ebiten.MouseButtonRight, layer) {
-			mouseButton = ebiten.MouseButtonRight
-		}
 		off := p.Sub(w.Rect.Min)
 		w.CursorMoveEvent.Fire(&WidgetCursorMoveEventArgs{
 			Widget:  w,
-			Button:  mouseButton,
 			OffsetX: off.X,
 			OffsetY: off.Y,
+			DiffX:   p.X - w.lastUpdateCursorPosition.X,
+			DiffY:   p.Y - w.lastUpdateCursorPosition.Y,
 		})
+
+		w.lastUpdateCursorPosition = p
 	}
 
 	if entered && len(w.CursorHovered) > 0 {


### PR DESCRIPTION
- Adding move event to Widget to capture Mouse Cursor movement inside the Widget rect
- Adding move event to Button to capture Mouse Cursor movement inside the Button rect, reusing ButtonCursorHoverHandlerFunc and ButtonHoverEventArgs to make it compatible to older versions.
- Enhancing Button widget demo to showcase new event

This feature would also allow implementing a solution for #133.