### PR TITLE
fix Text widget width calculation in `measure()`

### DIFF
--- a/widget/text.go
+++ b/widget/text.go
@@ -341,16 +341,21 @@ func (t *Text) measure() {
 		if t.MaxWidth > 0 || t.processBBCode {
 			var newLine []string
 			newLineWidth := float64(t.Inset.Left + t.Inset.Right)
+			spaceWidth := fixedInt26_6ToFloat64(font.MeasureString(t.Face, " "))
 			words := strings.Split(s.Text(), " ")
-			for _, word := range words {
-				wordWidth := fixedInt26_6ToFloat64(font.MeasureString(t.Face, word+" "))
+			for i, word := range words {
+				var wordWidth float64
+				if t.processBBCode && t.bbcodeRegex.MatchString(word) {
+					// Strip out any bbcodes from size calculation
+					cleaned := t.bbcodeRegex.ReplaceAllString(word, "")
+					wordWidth = fixedInt26_6ToFloat64(font.MeasureString(t.Face, cleaned))
+				} else {
+					wordWidth = fixedInt26_6ToFloat64(font.MeasureString(t.Face, word))
+				}
 
-				// Strip out any bbcodes from size calculation
-				if t.processBBCode {
-					if t.bbcodeRegex.MatchString(word) {
-						cleaned := t.bbcodeRegex.ReplaceAllString(word, "")
-						wordWidth = fixedInt26_6ToFloat64(font.MeasureString(t.Face, cleaned+" "))
-					}
+				// Don't add the space to the last chunk.
+				if i != len(words)-1 {
+					wordWidth += spaceWidth
 				}
 
 				// If the new word doesn't push this past the max width continue adding to the current line


### PR DESCRIPTION
The bug was something like an off-by-one mistake:
an extra space width was added to the Text's width if BBCodes were enabled.

Also avoid calculating the word width if we're about to discard that result when removing the BB-code tags. Instead, check for the tags first and then calculate the width one way or another.