### PR TITLE
Add "mask" to button

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,6 +55,16 @@
 			"args": []
 		},
 		{
+			"name": "Launch Button with Mask",
+			"type": "go",
+			"request": "launch",
+			"mode": "debug",
+			"program": "${workspaceFolder}/_examples/widget_demos/button_mask",
+			"cwd": "${workspaceFolder}/_examples/widget_demos/button_mask",
+			"env": {},
+			"args": []
+		},
+		{
 			"name": "Launch Checkbox",
 			"type": "go",
 			"request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,8 +59,8 @@
 			"type": "go",
 			"request": "launch",
 			"mode": "debug",
-			"program": "${workspaceFolder}/_examples/widget_demos/button_mask",
-			"cwd": "${workspaceFolder}/_examples/widget_demos/button_mask",
+			"program": "${workspaceFolder}/_examples/widget_demos/button_with_mask",
+			"cwd": "${workspaceFolder}/_examples/widget_demos/button_with_mask",
 			"env": {},
 			"args": []
 		},

--- a/_examples/widget_demos/button_mask/main.go
+++ b/_examples/widget_demos/button_mask/main.go
@@ -75,6 +75,21 @@ func main() {
 			println("button clicked")
 		}),
 
+		// add a handler that reacts to entering the button with the cursor
+		widget.ButtonOpts.CursorEnteredHandler(func(args *widget.ButtonHoverEventArgs) {
+			println("cursor entered button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY)
+		}),
+
+		// add a handler that reacts to moving the cursor on the button
+		widget.ButtonOpts.CursorMovedHandler(func(args *widget.ButtonHoverEventArgs) {
+			println("cursor moved on button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY, "diffX =", args.DiffX, "diffY =", args.DiffY)
+		}),
+
+		// add a handler that reacts to exiting the button with the cursor
+		widget.ButtonOpts.CursorExitedHandler(func(args *widget.ButtonHoverEventArgs) {
+			println("cursor exited button: entered =", args.Entered, "offsetX =", args.OffsetX, "offsetY =", args.OffsetY)
+		}),
+
 		// Indicate that this button should not be submitted when enter or space are pressed
 		// widget.ButtonOpts.DisableDefaultKeys(),
 	)

--- a/_examples/widget_demos/button_mask/main.go
+++ b/_examples/widget_demos/button_mask/main.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"image/color"
+	"log"
+
+	"github.com/ebitenui/ebitenui"
+	"github.com/ebitenui/ebitenui/image"
+	"github.com/ebitenui/ebitenui/widget"
+	"github.com/golang/freetype/truetype"
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/gofont/goregular"
+)
+
+// Game object used by ebiten
+type game struct {
+	ui  *ebitenui.UI
+	btn *widget.Button
+}
+
+func main() {
+	// load images for button states: idle, hover, and pressed
+	buttonImage, _ := loadButtonImage()
+
+	// load button text font
+	face, _ := loadFont(20)
+
+	// construct a new container that serves as the root of the UI hierarchy
+	rootContainer := widget.NewContainer(
+		// the container will use a plain color as its background
+		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0x13, 0x1a, 0x22, 0xff})),
+
+		// the container will use an anchor layout to layout its single child widget
+		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+	)
+
+	// construct a button
+	button := widget.NewButton(
+		// set general widget options
+		widget.ButtonOpts.WidgetOpts(
+			// instruct the container's anchor layout to center the button both horizontally and vertically
+			widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
+				HorizontalPosition: widget.AnchorLayoutPositionCenter,
+				VerticalPosition:   widget.AnchorLayoutPositionCenter,
+			}),
+			widget.WidgetOpts.MinSize(100, 100),
+		),
+
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		//widget.ButtonOpts.Text("Hello, World!", face, &widget.ButtonTextColor{
+		//widget.ButtonOpts.Text("Hello, [color=FF00FF]World![/color]", face, &widget.ButtonTextColor{
+		widget.ButtonOpts.Text("Hello!", face, &widget.ButtonTextColor{
+			Idle:  color.NRGBA{255, 255, 255, 255},
+			Hover: color.NRGBA{0, 0, 0, 255},
+		}),
+		//widget.ButtonOpts.TextProcessBBCode(true),
+		// specify that the button's text needs some padding for correct display
+		/*
+			widget.ButtonOpts.TextPadding(widget.Insets{
+				Left:   30,
+				Right:  30,
+				Top:    5,
+				Bottom: 5,
+			}),
+		*/
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			println("button clicked")
+		}),
+
+		// Indicate that this button should not be submitted when enter or space are pressed
+		// widget.ButtonOpts.DisableDefaultKeys(),
+	)
+
+	// add the button as a child of the container
+	rootContainer.AddChild(button)
+
+	// construct the UI
+	ui := ebitenui.UI{
+		Container: rootContainer,
+	}
+
+	// Ebiten setup
+	ebiten.SetWindowSize(400, 400)
+	ebiten.SetWindowTitle("Ebiten UI - Buttons with mask")
+
+	game := game{
+		ui:  &ui,
+		btn: button,
+	}
+
+	// run Ebiten main loop
+	err := ebiten.RunGame(&game)
+	if err != nil {
+		log.Println(err)
+	}
+}
+
+// Layout implements Game.
+func (g *game) Layout(outsideWidth int, outsideHeight int) (int, int) {
+	return outsideWidth, outsideHeight
+}
+
+// Update implements Game.
+func (g *game) Update() error {
+	// update the UI
+	g.ui.Update()
+	if inpututil.IsKeyJustPressed(ebiten.KeyB) {
+		g.btn.Click()
+	}
+
+	//Test that you can call Click on the focused widget.
+	if inpututil.IsKeyJustPressed(ebiten.KeyF) {
+		if btn, ok := g.ui.GetFocusedWidget().(*widget.Button); ok {
+			btn.Click()
+		}
+	}
+
+	return nil
+}
+
+// Draw implements Ebiten's Draw method.
+func (g *game) Draw(screen *ebiten.Image) {
+	// draw the UI onto the screen
+	g.ui.Draw(screen)
+}
+
+func loadButtonImage() (*widget.ButtonImage, error) {
+	idleImage := ebiten.NewImage(100, 100)
+	idleImage.Fill(color.RGBA{R: 80, G: 80, B: 80, A: 255})
+	vector.DrawFilledCircle(idleImage, float32(idleImage.Bounds().Dx())/2, float32(idleImage.Bounds().Dy())/2, 45, color.Black, true)
+	vector.DrawFilledCircle(idleImage, float32(idleImage.Bounds().Dx())/2, float32(idleImage.Bounds().Dy())/2, 20, color.RGBA{R: 80, G: 80, B: 80, A: 255}, true)
+	idle := image.NewNineSlice(idleImage, [3]int{0, idleImage.Bounds().Dx(), 0}, [3]int{0, idleImage.Bounds().Dy(), 0})
+
+	hoverImage := ebiten.NewImage(100, 100)
+	hoverImage.Fill(color.RGBA{R: 80, G: 80, B: 80, A: 255})
+	vector.DrawFilledCircle(hoverImage, float32(hoverImage.Bounds().Dx())/2, float32(hoverImage.Bounds().Dy())/2, 45, color.White, true)
+	vector.DrawFilledCircle(hoverImage, float32(hoverImage.Bounds().Dx())/2, float32(hoverImage.Bounds().Dy())/2, 20, color.RGBA{R: 80, G: 80, B: 80, A: 255}, true)
+	hover := image.NewNineSlice(hoverImage, [3]int{0, hoverImage.Bounds().Dx(), 0}, [3]int{0, hoverImage.Bounds().Dy(), 0})
+
+	pressedImage := ebiten.NewImage(100, 100)
+	pressedImage.Fill(color.RGBA{R: 80, G: 80, B: 80, A: 255})
+	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 45, color.RGBA{R: 255, G: 0, B: 0, A: 255}, true)
+	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 20, color.RGBA{R: 80, G: 80, B: 80, A: 255}, true)
+	pressed := image.NewNineSlice(pressedImage, [3]int{0, pressedImage.Bounds().Dx(), 0}, [3]int{0, pressedImage.Bounds().Dy(), 0})
+
+	maskImage := ebiten.NewImage(100, 100)
+	maskImage.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 255})
+	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 45, color.RGBA{R: 255, G: 255, B: 255, A: 255}, true)
+	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 20, color.RGBA{R: 0, G: 0, B: 0, A: 255}, true)
+	mask := image.NewNineSlice(maskImage, [3]int{0, maskImage.Bounds().Dx(), 0}, [3]int{0, maskImage.Bounds().Dy(), 0})
+
+	return &widget.ButtonImage{
+		Idle:    idle,
+		Hover:   hover,
+		Pressed: pressed,
+		Mask:    mask,
+	}, nil
+}
+
+func loadFont(size float64) (font.Face, error) {
+	ttfFont, err := truetype.Parse(goregular.TTF)
+	if err != nil {
+		return nil, err
+	}
+
+	return truetype.NewFace(ttfFont, &truetype.Options{
+		Size:    size,
+		DPI:     72,
+		Hinting: font.HintingFull,
+	}), nil
+}

--- a/_examples/widget_demos/button_with_mask/main.go
+++ b/_examples/widget_demos/button_with_mask/main.go
@@ -53,22 +53,10 @@ func main() {
 		widget.ButtonOpts.Image(buttonImage),
 
 		// specify the button's text, the font face, and the color
-		//widget.ButtonOpts.Text("Hello, World!", face, &widget.ButtonTextColor{
-		//widget.ButtonOpts.Text("Hello, [color=FF00FF]World![/color]", face, &widget.ButtonTextColor{
 		widget.ButtonOpts.Text("Hello!", face, &widget.ButtonTextColor{
 			Idle:  color.NRGBA{255, 255, 255, 255},
 			Hover: color.NRGBA{0, 0, 0, 255},
 		}),
-		//widget.ButtonOpts.TextProcessBBCode(true),
-		// specify that the button's text needs some padding for correct display
-		/*
-			widget.ButtonOpts.TextPadding(widget.Insets{
-				Left:   30,
-				Right:  30,
-				Top:    5,
-				Bottom: 5,
-			}),
-		*/
 
 		// add a handler that reacts to clicking the button
 		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
@@ -149,27 +137,27 @@ func (g *game) Draw(screen *ebiten.Image) {
 
 func loadButtonImage() (*widget.ButtonImage, error) {
 	idleImage := ebiten.NewImage(100, 100)
-	idleImage.Fill(color.RGBA{R: 80, G: 80, B: 80, A: 255})
+	idleImage.Fill(color.NRGBA{R: 80, G: 80, B: 80, A: 255})
 	vector.DrawFilledCircle(idleImage, float32(idleImage.Bounds().Dx())/2, float32(idleImage.Bounds().Dy())/2, 45, color.Black, true)
-	vector.DrawFilledCircle(idleImage, float32(idleImage.Bounds().Dx())/2, float32(idleImage.Bounds().Dy())/2, 20, color.RGBA{R: 80, G: 80, B: 80, A: 255}, true)
+	vector.DrawFilledCircle(idleImage, float32(idleImage.Bounds().Dx())/2, float32(idleImage.Bounds().Dy())/2, 20, color.NRGBA{R: 80, G: 80, B: 80, A: 255}, true)
 	idle := image.NewNineSlice(idleImage, [3]int{0, idleImage.Bounds().Dx(), 0}, [3]int{0, idleImage.Bounds().Dy(), 0})
 
 	hoverImage := ebiten.NewImage(100, 100)
-	hoverImage.Fill(color.RGBA{R: 80, G: 80, B: 80, A: 255})
+	hoverImage.Fill(color.NRGBA{R: 80, G: 80, B: 80, A: 255})
 	vector.DrawFilledCircle(hoverImage, float32(hoverImage.Bounds().Dx())/2, float32(hoverImage.Bounds().Dy())/2, 45, color.White, true)
-	vector.DrawFilledCircle(hoverImage, float32(hoverImage.Bounds().Dx())/2, float32(hoverImage.Bounds().Dy())/2, 20, color.RGBA{R: 80, G: 80, B: 80, A: 255}, true)
+	vector.DrawFilledCircle(hoverImage, float32(hoverImage.Bounds().Dx())/2, float32(hoverImage.Bounds().Dy())/2, 20, color.NRGBA{R: 80, G: 80, B: 80, A: 255}, true)
 	hover := image.NewNineSlice(hoverImage, [3]int{0, hoverImage.Bounds().Dx(), 0}, [3]int{0, hoverImage.Bounds().Dy(), 0})
 
 	pressedImage := ebiten.NewImage(100, 100)
-	pressedImage.Fill(color.RGBA{R: 80, G: 80, B: 80, A: 255})
-	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 45, color.RGBA{R: 255, G: 0, B: 0, A: 255}, true)
-	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 20, color.RGBA{R: 80, G: 80, B: 80, A: 255}, true)
+	pressedImage.Fill(color.NRGBA{R: 80, G: 80, B: 80, A: 255})
+	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 45, color.NRGBA{R: 255, G: 0, B: 0, A: 255}, true)
+	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 20, color.NRGBA{R: 80, G: 80, B: 80, A: 255}, true)
 	pressed := image.NewNineSlice(pressedImage, [3]int{0, pressedImage.Bounds().Dx(), 0}, [3]int{0, pressedImage.Bounds().Dy(), 0})
 
 	maskImage := ebiten.NewImage(100, 100)
-	maskImage.Fill(color.RGBA{R: 0, G: 0, B: 0, A: 255})
-	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 45, color.RGBA{R: 255, G: 255, B: 255, A: 255}, true)
-	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 20, color.RGBA{R: 0, G: 0, B: 0, A: 255}, true)
+	maskImage.Fill(color.NRGBA{R: 0, G: 0, B: 0, A: 255})
+	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 45, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, true)
+	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 20, color.NRGBA{R: 0, G: 0, B: 0, A: 255}, true)
 	mask := image.NewNineSlice(maskImage, [3]int{0, maskImage.Bounds().Dx(), 0}, [3]int{0, maskImage.Bounds().Dy(), 0})
 
 	return &widget.ButtonImage{

--- a/_examples/widget_demos/button_with_mask/main.go
+++ b/_examples/widget_demos/button_with_mask/main.go
@@ -52,6 +52,9 @@ func main() {
 		// specify the images to use
 		widget.ButtonOpts.Image(buttonImage),
 
+		// specify to ignore transparent pixels for mouse events
+		widget.ButtonOpts.IgnoreTransparentPixels(true),
+
 		// specify the button's text, the font face, and the color
 		widget.ButtonOpts.Text("Hello!", face, &widget.ButtonTextColor{
 			Idle:  color.NRGBA{255, 255, 255, 255},
@@ -137,34 +140,21 @@ func (g *game) Draw(screen *ebiten.Image) {
 
 func loadButtonImage() (*widget.ButtonImage, error) {
 	idleImage := ebiten.NewImage(100, 100)
-	idleImage.Fill(color.NRGBA{R: 80, G: 80, B: 80, A: 255})
 	vector.DrawFilledCircle(idleImage, float32(idleImage.Bounds().Dx())/2, float32(idleImage.Bounds().Dy())/2, 45, color.Black, true)
-	vector.DrawFilledCircle(idleImage, float32(idleImage.Bounds().Dx())/2, float32(idleImage.Bounds().Dy())/2, 20, color.NRGBA{R: 80, G: 80, B: 80, A: 255}, true)
 	idle := image.NewNineSlice(idleImage, [3]int{0, idleImage.Bounds().Dx(), 0}, [3]int{0, idleImage.Bounds().Dy(), 0})
 
 	hoverImage := ebiten.NewImage(100, 100)
-	hoverImage.Fill(color.NRGBA{R: 80, G: 80, B: 80, A: 255})
 	vector.DrawFilledCircle(hoverImage, float32(hoverImage.Bounds().Dx())/2, float32(hoverImage.Bounds().Dy())/2, 45, color.White, true)
-	vector.DrawFilledCircle(hoverImage, float32(hoverImage.Bounds().Dx())/2, float32(hoverImage.Bounds().Dy())/2, 20, color.NRGBA{R: 80, G: 80, B: 80, A: 255}, true)
 	hover := image.NewNineSlice(hoverImage, [3]int{0, hoverImage.Bounds().Dx(), 0}, [3]int{0, hoverImage.Bounds().Dy(), 0})
 
 	pressedImage := ebiten.NewImage(100, 100)
-	pressedImage.Fill(color.NRGBA{R: 80, G: 80, B: 80, A: 255})
 	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 45, color.NRGBA{R: 255, G: 0, B: 0, A: 255}, true)
-	vector.DrawFilledCircle(pressedImage, float32(pressedImage.Bounds().Dx())/2, float32(pressedImage.Bounds().Dy())/2, 20, color.NRGBA{R: 80, G: 80, B: 80, A: 255}, true)
 	pressed := image.NewNineSlice(pressedImage, [3]int{0, pressedImage.Bounds().Dx(), 0}, [3]int{0, pressedImage.Bounds().Dy(), 0})
-
-	maskImage := ebiten.NewImage(100, 100)
-	maskImage.Fill(color.NRGBA{R: 0, G: 0, B: 0, A: 255})
-	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 45, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, true)
-	vector.DrawFilledCircle(maskImage, float32(maskImage.Bounds().Dx())/2, float32(maskImage.Bounds().Dy())/2, 20, color.NRGBA{R: 0, G: 0, B: 0, A: 255}, true)
-	mask := image.NewNineSlice(maskImage, [3]int{0, maskImage.Bounds().Dx(), 0}, [3]int{0, maskImage.Bounds().Dy(), 0})
 
 	return &widget.ButtonImage{
 		Idle:    idle,
 		Hover:   hover,
 		Pressed: pressed,
-		Mask:    mask,
 	}, nil
 }
 

--- a/widget/button.go
+++ b/widget/button.go
@@ -132,7 +132,7 @@ var ButtonOpts ButtonOptions
 
 func NewButton(opts ...ButtonOpt) *Button {
 	b := &Button{
-		MaskColor: color.RGBA{R: 255, G: 255, B: 255, A: 255}, // white
+		MaskColor: color.NRGBA{R: 255, G: 255, B: 255, A: 255}, // white
 
 		hTextPosition: TextPositionCenter,
 		vTextPosition: TextPositionCenter,
@@ -506,11 +506,19 @@ func (b *Button) SetLocation(rect img.Rectangle) {
 		b.mask = make([][]bool, wy)
 		x := 0
 		y := 0
+
+		// convert alpha-premultiplied colors to non-alpha-premultiplied colors
+		red32, green32, blue32, alpha32 := b.MaskColor.RGBA()
+		red8 := uint8(red32 >> 8)
+		green8 := uint8(green32 >> 8)
+		blue8 := uint8(blue32 >> 8)
+		alpha8 := uint8(alpha32 >> 8)
+
 		for i := 0; i < len(pixels); i += 4 {
 			if b.mask[y] == nil {
 				b.mask[y] = make([]bool, wx)
 			}
-			if pixels[i] == 255 && pixels[i+1] == 255 && pixels[i+2] == 255 && pixels[i+3] == 255 {
+			if pixels[i] == red8 && pixels[i+1] == green8 && pixels[i+2] == blue8 && pixels[i+3] == alpha8 {
 				b.mask[y][x] = true
 			}
 			x++

--- a/widget/button.go
+++ b/widget/button.go
@@ -14,7 +14,6 @@ import (
 
 type Button struct {
 	Image                   *ButtonImage
-	mask                    []byte
 	IgnoreTransparentPixels bool
 	KeepPressedOnExit       bool
 	ToggleMode              bool
@@ -43,6 +42,7 @@ type Button struct {
 	widget            *Widget
 	container         *Container
 	graphic           *Graphic
+	mask              []byte
 	text              *Text
 	textLabel         string
 	textFace          font.Face
@@ -194,6 +194,10 @@ func (o ButtonOptions) Image(i *ButtonImage) ButtonOpt {
 	}
 }
 
+// IgnoreTransparentPixels disables mouse events like cursor entered,
+// moved and exited if the mouse pointer is over a pixel that is transparent
+// (alpha = 0). The source of pixels is Image.Idle. This options is
+// especially useful, if your button does not have a rectangular shape.
 func (o ButtonOptions) IgnoreTransparentPixels(ignoreTransparentPixels bool) ButtonOpt {
 	return func(b *Button) {
 		b.IgnoreTransparentPixels = ignoreTransparentPixels
@@ -763,10 +767,7 @@ func (b *Button) createWidget() {
 
 		WidgetOpts.MouseButtonReleasedHandler(func(args *WidgetMouseButtonReleasedEventArgs) {
 			if b.pressing && !b.widget.Disabled && args.Button == ebiten.MouseButtonLeft {
-				inside := false
-				if args.Inside && b.onMask(args.OffsetX, args.OffsetY) {
-					inside = true
-				}
+				inside := args.Inside && b.onMask(args.OffsetX, args.OffsetY)
 
 				b.ReleasedEvent.Fire(&ButtonReleasedEventArgs{
 					Button:  b,


### PR DESCRIPTION
Closes #133 

- Please see "button_with_mask" example ("button" still works as expected)
- "Mask" is created from the the given NineSlice image only (no Text, no Graphic), which is added to `(Image *ButtonImage).Idle` => not optimal yet
- The expected condition to fullfill `onMask(x, y)` is every 4th byte of the pixels array is > 0. This is not configurable

1. It would be better in general if button would create an offscreen image with all elements (like text, graphic, etc..) instead of directly drawing to screen. This would simply allow to use the offscreen image as mask and ignore e.g. all transparent pixels (A = 0). If you favor this approach, we can work together to get this done.

2. If you do not feel comfortable with including this into button-widget directly, we could add another widget and make it optional to use.