### PR TITLE
widget/button: Fixed issue with the 'TextColor.Pressed' not displayed on RadioGroup

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -561,7 +561,7 @@ func (b *Button) Render(screen *ebiten.Image, def DeferredRenderFunc) {
 		if b.text != nil {
 			if b.widget.Disabled && b.TextColor.Disabled != nil {
 				b.text.Color = b.TextColor.Disabled
-			} else if b.pressing && ((b.hovering || b.KeepPressedOnExit) || (b.ToggleMode && b.state == WidgetChecked) || b.justSubmitted) && b.TextColor.Pressed != nil {
+			} else if (b.pressing && (b.hovering || b.KeepPressedOnExit) || (b.ToggleMode && b.state == WidgetChecked) || b.justSubmitted) && b.TextColor.Pressed != nil {
 				b.text.Color = b.TextColor.Pressed
 			} else if (b.hovering || b.focused) && b.TextColor.Hover != nil {
 				b.text.Color = b.TextColor.Hover


### PR DESCRIPTION

A wrong parentheses made it so if the buttons where in a 'RadioGroup' the pressed one would have the 'Idle' color and not the 'Pressed' one