### PR TITLE
widget/container: Changed 'AddChildren' to be a variadic

### DIFF
--- a/_examples/widget_demos/gridlayout/main.go
+++ b/_examples/widget_demos/gridlayout/main.go
@@ -44,7 +44,6 @@ func main() {
 			widget.WidgetOpts.MinSize(100, 100),
 		),
 	)
-	rootContainer.AddChild(innerContainer1)
 
 	innerContainer2 := widget.NewContainer(
 		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0, 255, 0, 255})),
@@ -52,7 +51,6 @@ func main() {
 			widget.WidgetOpts.MinSize(100, 100),
 		),
 	)
-	rootContainer.AddChild(innerContainer2)
 
 	innerContainer3 := widget.NewContainer(
 		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0, 0, 255, 255})),
@@ -69,7 +67,6 @@ func main() {
 			widget.WidgetOpts.MinSize(100, 100),
 		),
 	)
-	rootContainer.AddChild(innerContainer3)
 
 	innerContainer4 := widget.NewContainer(
 		widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{0, 255, 255, 255})),
@@ -77,7 +74,13 @@ func main() {
 			widget.WidgetOpts.MinSize(100, 100),
 		),
 	)
-	rootContainer.AddChild(innerContainer4)
+
+	rootContainer.AddChild(
+		innerContainer1,
+		innerContainer2,
+		innerContainer3,
+		innerContainer4,
+	)
 	// construct the UI
 	ui := ebitenui.UI{
 		Container: rootContainer,


### PR DESCRIPTION
It does not brake any interface but it enhances it by allowing to send multiple childs in one call instead of having to do multiple calls to it.

This is something that potentially only bothers me but it's a nice improvement to the API as it's something always done that in some cases improves the readability and it does not do any harm and it's backwards compatible.