### PR TITLE
widget/scrollcontainer: Fixed issue with ScrollContainer content

### DIFF
--- a/widget/container.go
+++ b/widget/container.go
@@ -232,7 +232,7 @@ func (c *Container) SetLocation(rect img.Rectangle) {
 func (c *Container) Render(screen *ebiten.Image) {
 	c.init.Do()
 
-	if c.widget.Visibility == Visibility_Hide_Blocking || c.widget.Visibility == Visibility_Hide {
+	if !c.widget.IsVisible() {
 		return
 	}
 
@@ -250,7 +250,7 @@ func (c *Container) Render(screen *ebiten.Image) {
 
 	for _, ch := range c.children {
 		if cr, ok := ch.(Renderer); ok {
-			if ch.GetWidget().Visibility == Visibility_Hide_Blocking || ch.GetWidget().Visibility == Visibility_Hide {
+			if !ch.GetWidget().IsVisible() {
 				continue
 			}
 			cr.Render(screen)

--- a/widget/scrollcontainer.go
+++ b/widget/scrollcontainer.go
@@ -143,16 +143,18 @@ func (s *ScrollContainer) PreferredSize() (int, int) {
 func (s *ScrollContainer) SetupInputLayer(def input.DeferredSetupInputLayerFunc) {
 	s.init.Do()
 
-	s.content.GetWidget().ElevateToNewInputLayer(&input.Layer{
-		DebugLabel: "scroll container content",
-		EventTypes: input.LayerEventTypeAll ^ input.LayerEventTypeWheel,
-		BlockLower: true,
-		FullScreen: false,
-		RectFunc:   s.ViewRect,
-	})
+	if s.widget.IsVisible() {
+		s.content.GetWidget().ElevateToNewInputLayer(&input.Layer{
+			DebugLabel: "scroll container content",
+			EventTypes: input.LayerEventTypeAll ^ input.LayerEventTypeWheel,
+			BlockLower: true,
+			FullScreen: false,
+			RectFunc:   s.ViewRect,
+		})
 
-	if il, ok := s.content.(input.Layerer); ok {
-		il.SetupInputLayer(def)
+		if il, ok := s.content.(input.Layerer); ok {
+			il.SetupInputLayer(def)
+		}
 	}
 }
 

--- a/widget/tooltip.go
+++ b/widget/tooltip.go
@@ -205,7 +205,8 @@ func (t *ToolTip) idleState() toolTipState {
 	return func(parent *Widget) toolTipState {
 		if input.MouseButtonPressed(ebiten.MouseButtonLeft) ||
 			input.MouseButtonPressed(ebiten.MouseButtonMiddle) ||
-			input.MouseButtonPressed(ebiten.MouseButtonRight) {
+			input.MouseButtonPressed(ebiten.MouseButtonRight) ||
+			!parent.IsVisible() {
 			t.visible = false
 			parent.FireToolTipEvent(t.window, false)
 			return nil

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -668,6 +668,19 @@ func (widget *Widget) FireDragAndDropEvent(w *Window, show bool, dnd *DragAndDro
 	})
 }
 
+// IsVisible will check if this particular widget is visible by checking Visibility of it and
+// all the parents it has, as if one of the parents is not visible this widget will not be visible
+// even if it has Visibility_Show
+func (widget *Widget) IsVisible() bool {
+	if widget.Visibility != Visibility_Show {
+		return false
+	}
+	if widget.parent != nil {
+		return widget.parent.IsVisible()
+	}
+	return true
+}
+
 // RenderWithDeferred renders r to screen. This function should not be called directly.
 func RenderDeferred(screen *ebiten.Image) {
 	defer func(d []RenderFunc) {


### PR DESCRIPTION
:warning: THIS PR IS OPENED FROM #178 AS IT NEEDS THE `IsVisible` INTRODUCED THERE :warning: 

After it was rendered once it was kept on the top layer and blocking any other interaction

There are other places in which the `.ElevateToNewInputLayer` is also used, i did not test those if they have the same issue but are this ones:
* dnd
* window
* slider
* combobutton: And this one has logic to not do it if it's not "ContentVisible" and that's where I got the idea to use the `IsVisible`

Closes #162 