### PR TITLE
widget/graphic: Added 'GraphicImage' to allow 'Idle' and 'Disabled' images

### DIFF
--- a/_examples/widget_demos/imagebutton/main.go
+++ b/_examples/widget_demos/imagebutton/main.go
@@ -22,6 +22,7 @@ func main() {
 	// load images for button states: idle, hover, and pressed
 	buttonImage := loadButtonImage()
 	buttonIcon := loadButtonIcon()
+	buttonDisabledIcon := loadDisabledButtonIcon()
 
 	// construct a new container that serves as the root of the UI hierarchy
 	rootContainer := widget.NewContainer(
@@ -45,6 +46,13 @@ func main() {
 			VerticalPosition:   widget.AnchorLayoutPositionCenter,
 		})),
 	)
+	btnIconG := widget.NewGraphic(
+		widget.GraphicOpts.Images(&widget.GraphicImage{
+			Idle:     buttonIcon,
+			Disabled: buttonDisabledIcon,
+		},
+		),
+	)
 	// construct a pressable button
 	button := widget.NewButton(
 		// specify the images to use
@@ -53,6 +61,7 @@ func main() {
 		// add a handler that reacts to clicking the button
 		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
 			println("button clicked")
+			btnIconG.GetWidget().Disabled = !btnIconG.GetWidget().Disabled
 		}),
 	)
 	buttonStackedLayout.AddChild(button)
@@ -61,7 +70,9 @@ func main() {
 	// you may see a transparent rectangle inside the button.
 	// To fix that, either use a separate button image (that can fit the image)
 	// or add an appropriate stretching.
-	buttonStackedLayout.AddChild(widget.NewGraphic(widget.GraphicOpts.Image(buttonIcon)))
+	buttonStackedLayout.AddChild(
+		btnIconG,
+	)
 
 	// since our button is a multi-widget object, add its wrapping container
 	rootContainer.AddChild(buttonStackedLayout)
@@ -107,6 +118,14 @@ func loadButtonIcon() *ebiten.Image {
 	// in reality it could be an arbitrary *ebiten.Image
 	icon := ebiten.NewImage(32, 32)
 	ebitenutil.DrawCircle(icon, 16, 16, 16, color.RGBA{R: 0x71, G: 0x56, B: 0xbd, A: 255})
+	return icon
+}
+
+func loadDisabledButtonIcon() *ebiten.Image {
+	// we'll use a circle as an icon image
+	// in reality it could be an arbitrary *ebiten.Image
+	icon := ebiten.NewImage(32, 32)
+	ebitenutil.DrawCircle(icon, 16, 16, 16, color.RGBA{R: 250, G: 0x56, B: 0xbd, A: 255})
 	return icon
 }
 

--- a/widget/graphic.go
+++ b/widget/graphic.go
@@ -11,11 +11,17 @@ import (
 type Graphic struct {
 	Image          *ebiten.Image
 	ImageNineSlice *image.NineSlice
+	Images         *GraphicImage
 
 	widgetOpts []WidgetOpt
 
 	init   *MultiOnce
 	widget *Widget
+}
+
+type GraphicImage struct {
+	Idle     *ebiten.Image
+	Disabled *ebiten.Image
 }
 
 type GraphicOpt func(g *Graphic)
@@ -36,7 +42,15 @@ func NewGraphic(opts ...GraphicOpt) *Graphic {
 		o(g)
 	}
 
+	g.validate()
+
 	return g
+}
+
+func (g *Graphic) validate() {
+	if (g.Image != nil && g.ImageNineSlice != nil) || (g.Image != nil && g.Images != nil) || (g.ImageNineSlice != nil && g.Images != nil) {
+		panic("Only one type of image: Image, ImageNineSlice or Images can be defined")
+	}
 }
 
 func (o GraphicOptions) WidgetOpts(opts ...WidgetOpt) GraphicOpt {
@@ -48,6 +62,12 @@ func (o GraphicOptions) WidgetOpts(opts ...WidgetOpt) GraphicOpt {
 func (o GraphicOptions) Image(i *ebiten.Image) GraphicOpt {
 	return func(g *Graphic) {
 		g.Image = i
+	}
+}
+
+func (o GraphicOptions) Images(i *GraphicImage) GraphicOpt {
+	return func(g *Graphic) {
+		g.Images = i
 	}
 }
 
@@ -88,15 +108,26 @@ func (g *Graphic) Update() {
 }
 
 func (g *Graphic) draw(screen *ebiten.Image) {
-	if g.Image != nil {
-		opts := ebiten.DrawImageOptions{}
-		w, h := g.Image.Size()
-		opts.GeoM.Translate(float64((g.widget.Rect.Dx()-w)/2), float64((g.widget.Rect.Dy()-h)/2))
-		g.widget.drawImageOptions(&opts)
-		screen.DrawImage(g.Image, &opts)
-	} else if g.ImageNineSlice != nil {
+	if g.ImageNineSlice != nil {
 		g.ImageNineSlice.Draw(screen, g.widget.Rect.Dx(), g.widget.Rect.Dy(), g.widget.drawImageOptions)
+		return
 	}
+	if g.Image != nil {
+		g.Images = &GraphicImage{
+			Idle: g.Image,
+		}
+	}
+
+	i := g.Images.Idle
+	if g.widget.Disabled && g.Images.Disabled != nil {
+		i = g.Images.Disabled
+	}
+
+	opts := ebiten.DrawImageOptions{}
+	w, h := i.Size()
+	opts.GeoM.Translate(float64((g.widget.Rect.Dx()-w)/2), float64((g.widget.Rect.Dy()-h)/2))
+	g.widget.drawImageOptions(&opts)
+	screen.DrawImage(i, &opts)
 }
 
 func (g *Graphic) createWidget() {


### PR DESCRIPTION
Added it as a new function+attribute 'Images' to not break any code using 'Image'.

The other possible option could be to have `Image(interface{})` and  on the `New` check what type is, if it's an `ebiten.Image` or `ebitenui.GraphicImage` and use one or the other.

This also made me think on the `Widget.Disabled` if it should propagate down. RN we check if the current `widget` is Disabled, but if any parent is Disabled because we should potentially also disable the child like the `Visibility` if it's `Hide`.

I can open a separated issue for that thought if you want to.

Related to #168 