### PR TITLE
widget/button: Added 2 new function 'Press' and 'Release'

### DIFF
--- a/_examples/widget_demos/button/main.go
+++ b/_examples/widget_demos/button/main.go
@@ -155,6 +155,12 @@ func (g *game) Update() error {
 		}
 	}
 
+	if inpututil.IsKeyJustPressed(ebiten.KeyG) {
+		g.btn.Press()
+	} else if inpututil.IsKeyJustReleased(ebiten.KeyG) {
+		g.btn.Release()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
So we can use Keybinds to totally emulate click on a button.

This works as expected by emulating a Left click on the button so we do not have to copy code around.

Another solution, longer, would be to also support a `KeyPressedEvent` event as we do for the `MouseButtonPressedEvent` but I think this current solution is easier.

Closes #169 