### PR TITLE
Fix focus on invisible or disabled elements

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -53,7 +53,7 @@ func (u *UI) Update() {
 	u.handleFocusChangeRequest()
 
 	//If widget is not visible or disabled, change focus to next widget
-	if u.focusedWidget != nil && (u.focusedWidget.GetWidget().Disabled || u.focusedWidget.GetWidget().Visibility != widget.Visibility_Show) {
+	if u.focusedWidget != nil && (u.focusedWidget.GetWidget().Disabled || !u.focusedWidget.GetWidget().IsVisible()) {
 		u.ChangeFocus(widget.FOCUS_NEXT)
 	}
 
@@ -222,7 +222,7 @@ func (u *UI) handleFocusChangeRequest() {
 func (u *UI) ChangeFocus(direction widget.FocusDirection) {
 	if u.focusedWidget != nil {
 		if next := u.focusedWidget.(widget.Focuser).GetFocus(direction); next != nil {
-			if !next.GetWidget().Disabled && next.GetWidget().Visibility == widget.Visibility_Show {
+			if !next.GetWidget().Disabled && next.GetWidget().IsVisible() {
 				next.Focus(true)
 			}
 		}

--- a/ui.go
+++ b/ui.go
@@ -52,6 +52,11 @@ func (u *UI) Update() {
 
 	u.handleFocusChangeRequest()
 
+	//If widget is not visible or disabled, change focus to next widget
+	if u.focusedWidget != nil && (u.focusedWidget.GetWidget().Disabled || u.focusedWidget.GetWidget().Visibility != widget.Visibility_Show) {
+		u.ChangeFocus(widget.FOCUS_NEXT)
+	}
+
 	index := 0
 	for ; index < len(u.windows); index++ {
 		if u.windows[index].DrawLayer < 0 {
@@ -217,7 +222,7 @@ func (u *UI) handleFocusChangeRequest() {
 func (u *UI) ChangeFocus(direction widget.FocusDirection) {
 	if u.focusedWidget != nil {
 		if next := u.focusedWidget.(widget.Focuser).GetFocus(direction); next != nil {
-			if !next.GetWidget().Disabled {
+			if !next.GetWidget().Disabled && next.GetWidget().Visibility == widget.Visibility_Show {
 				next.Focus(true)
 			}
 		}

--- a/widget/container.go
+++ b/widget/container.go
@@ -309,7 +309,7 @@ func (c *Container) GetFocusers() []Focuser {
 		switch v := child.(type) {
 		case Focuser:
 			if widget, ok := v.(HasWidget); ok {
-				if v.TabOrder() >= 0 && !widget.GetWidget().Disabled {
+				if v.TabOrder() >= 0 && !widget.GetWidget().Disabled && widget.GetWidget().IsVisible() {
 					result = append(result, v)
 				}
 			}

--- a/widget/scrollcontainer.go
+++ b/widget/scrollcontainer.go
@@ -199,7 +199,7 @@ func (s *ScrollContainer) GetFocusers() []Focuser {
 	switch v := s.content.(type) {
 	case Focuser:
 		if widget, ok := v.(HasWidget); ok {
-			if v.TabOrder() >= 0 && !widget.GetWidget().Disabled {
+			if v.TabOrder() >= 0 && !widget.GetWidget().Disabled && widget.GetWidget().IsVisible() {
 				result = append(result, v)
 			}
 		}


### PR DESCRIPTION
When an element is focus and suddenly is disabled or hidden it will keep the focus which is wrong, now it will try to set focus to the next element.