### PR TITLE
add utility function to create nineslice image from just a border size

### DIFF
--- a/image/nineslice.go
+++ b/image/nineslice.go
@@ -49,6 +49,13 @@ func NewNineSliceSimple(image *ebiten.Image, borderWidthHeight int, centerWidthH
 	}
 }
 
+// NewNineSliceSimple constructs a new NineSlice from image. borderWidthHeight specifies the width of the
+// left and right column and the height of the top and bottom row. The center width and height is computed as
+// the width of image minus 2*borderWidthHeight
+func NewNineSliceBorder(image *ebiten.Image, borderWidthHeight int) *NineSlice {
+    return NewNineSliceSimple(image, borderWidthHeight, image.Bounds().Dx() - borderWidthHeight * 2)
+}
+
 // NewNineSliceColor constructs a new NineSlice that when drawn fills with color c.
 func NewNineSliceColor(c color.Color) *NineSlice {
 	if c == nil {

--- a/image/nineslice_test.go
+++ b/image/nineslice_test.go
@@ -41,3 +41,17 @@ func Test_NewNineSliceColor(t *testing.T) {
 	n = NewNineSliceColor(color.RGBA{0, 0, 0, 0})
 	is.Equal(n.transparent, true)
 }
+
+func Test_NewNineSliceBorder(t *testing.T) {
+    is := is.New(t)
+
+    img := newImageEmptySize(20, 20, t)
+    n := NewNineSliceBorder(img, 3)
+
+    is.Equal(n.widths[0], 3)
+    is.Equal(n.widths[1], 20 - 3 * 2)
+    is.Equal(n.widths[2], 3)
+    is.Equal(n.heights[0], 3)
+    is.Equal(n.heights[1], 20 - 3 * 2)
+    is.Equal(n.heights[2], 3)
+}


### PR DESCRIPTION
Add a function
```
NewNineSliceBorder(image *ebiten.Image, borderWidthHeight int)
```
that constructs a nine slice image by assuming the center width/height is image.width - border*2