### PR TITLE
remove configure, replace with modifying the ClickEvent directly

### DIFF
--- a/_examples/toolbar/main.go
+++ b/_examples/toolbar/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"github.com/ebitenui/ebitenui"
 	"github.com/ebitenui/ebitenui/widget"
+	"github.com/ebitenui/ebitenui/event"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	"golang.org/x/image/colornames"
@@ -49,18 +50,14 @@ func main() {
 	//
 	// Example 1: Configure the "Help" button to display a message in console when it's pressed.
 	//
-	toolbar.helpButton.Configure(
-		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
-			println("The help button was pressed!")
-		}),
-	)
+	toolbar.helpButton.ClickedEvent.AddHandler(event.WrapHandler(func(args *widget.ButtonClickedEventArgs) {
+		println("The help button was pressed!")
+	}))
 
 	// Example 2: Configure the "Quit" menu entry to end the program when it's pressed.
-	toolbar.quitButton.Configure(
-		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
-			game.exit = true
-		}),
-	)
+	toolbar.quitButton.ClickedEvent.AddHandler(event.WrapHandler(func(args *widget.ButtonClickedEventArgs) {
+		game.exit = true
+	}))
 
 	// Run the game.
 	if err := ebiten.RunGame(&game); err != nil {

--- a/_examples/toolbar/toolbar.go
+++ b/_examples/toolbar/toolbar.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ebitenui/ebitenui"
 	"github.com/ebitenui/ebitenui/image"
 	"github.com/ebitenui/ebitenui/widget"
+	"github.com/ebitenui/ebitenui/event"
 	"golang.org/x/image/colornames"
 	goimage "image"
 	"image/color"
@@ -60,12 +61,11 @@ func newToolbar(ui *ebitenui.UI, res *resources) *toolbar {
 		load = newToolbarMenuEntry(res, "Load")
 		quit = newToolbarMenuEntry(res, "Quit")
 	)
-	file.Configure(
-		// Make the toolbar entry open a menu with our "save" and "load" entries  when the user clicks it.
-		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
-			openToolbarMenu(args.Button.GetWidget(), ui, save, load, quit)
-		}),
-	)
+
+    // Make the toolbar entry open a menu with our "save" and "load" entries  when the user clicks it.
+	file.ClickedEvent.AddHandler(event.WrapHandler(func(args *widget.ButtonClickedEventArgs) {
+		openToolbarMenu(args.Button.GetWidget(), ui, save, load, quit)
+	}))
 	root.AddChild(file)
 
 	//
@@ -80,11 +80,9 @@ func newToolbar(ui *ebitenui.UI, res *resources) *toolbar {
 		copy  = newToolbarMenuEntry(res, "Copy")
 		paste = newToolbarMenuEntry(res, "Paste")
 	)
-	edit.Configure(
-		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
-			openToolbarMenu(args.Button.GetWidget(), ui, undo, redo, cut, copy, paste)
-		}),
-	)
+	edit.ClickedEvent.AddHandler(event.WrapHandler(func(args *widget.ButtonClickedEventArgs) {
+		openToolbarMenu(args.Button.GetWidget(), ui, undo, redo, cut, copy, paste)
+	}))
 	root.AddChild(edit)
 
 	//

--- a/event/event.go
+++ b/event/event.go
@@ -30,6 +30,14 @@ type deferredAddHandler struct {
 	handler handler
 }
 
+func WrapHandler[T any](f func(T)) HandlerFunc {
+    return func(args interface{}) {
+        if arg, ok := args.(T); ok {
+            f(arg)
+        }
+    }
+}
+
 // AddHandler registers event handler h with e. It returns a function to remove h from e if desired.
 func (e *Event) AddHandler(h HandlerFunc) RemoveHandlerFunc {
 	e.idCounter++

--- a/event/event.go
+++ b/event/event.go
@@ -30,6 +30,9 @@ type deferredAddHandler struct {
 	handler handler
 }
 
+// WrapHandler accepts a function of one argument and converts it into a HandlerFunc.
+// Use this function when passing adding a new handler to an event object, such as
+// button.ClickedEvent.AddHandler(WrapHandler(func (args *widget.ButtonClickedEventArgs){ ... }))
 func WrapHandler[T any](f func(T)) HandlerFunc {
     return func(args interface{}) {
         if arg, ok := args.(T); ok {

--- a/widget/button.go
+++ b/widget/button.go
@@ -448,12 +448,6 @@ func (b *Button) getStateChangedEvent() *event.Event {
 	return b.StateChangedEvent
 }
 
-func (b *Button) Configure(opts ...ButtonOpt) {
-	for _, o := range opts {
-		o(b)
-	}
-}
-
 /** Focuser Interface - Start **/
 
 func (b *Button) Focus(focused bool) {

--- a/widget/progressbar.go
+++ b/widget/progressbar.go
@@ -114,12 +114,6 @@ func (o ProgressBarOptions) Values(min int, max int, current int) ProgressBarOpt
 	}
 }
 
-func (s *ProgressBar) Configure(opts ...ProgressBarOpt) {
-	for _, o := range opts {
-		o(s)
-	}
-}
-
 func (s *ProgressBar) GetWidget() *Widget {
 	s.init.Do()
 	return s.widget


### PR DESCRIPTION
Remove button.Configure() and progressbar.Configure(). Instead just call button.ClickedEvent.AddHandler() directly.

This adds a generic function to wrap a handler in the way that a handler expects.