### PR TITLE
Add 'TOOLTIP_POS_ABSOLUTE' and 'TOOLTIP_POS_SCREEN' positioning for tooltips

### DIFF
--- a/_examples/widget_demos/tooltips/main.go
+++ b/_examples/widget_demos/tooltips/main.go
@@ -154,7 +154,7 @@ func main() {
 
 	// The NewTextToolTip defaults to follow the cursor
 	// But every parameter is available to update after it has been created
-	btn3ToolTip.Position = widget.TOOLTIP_POS_SCREEN
+	btn3ToolTip.Position = widget.TOOLTIP_POS_ABSOLUTE
 	btn3ToolTip.Offset.X = 200
 	btn3ToolTip.Offset.Y = 200
 	btn3ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE

--- a/_examples/widget_demos/tooltips/main.go
+++ b/_examples/widget_demos/tooltips/main.go
@@ -209,7 +209,7 @@ func main() {
 	btn4ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
 	btn4ToolTip.ContentOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
 	btn4ToolTip.WidgetOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
-	btn4ToolTip.WidgetOriginVertical = widget.TOOLTIP_ANCHOR_START
+	btn4ToolTip.WidgetOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
 	btn4ToolTip.Delay = 0
 
 	// construct a button

--- a/_examples/widget_demos/tooltips/main.go
+++ b/_examples/widget_demos/tooltips/main.go
@@ -72,8 +72,8 @@ func main() {
 				widget.ToolTipOpts.Position(widget.TOOLTIP_POS_WIDGET),
 				// When the Position is set to TOOLTIP_POS_WIDGET, you can configure where it opens with the optional parameters below
 				// They will default to what you see below if you do not provide them
-				widget.ToolTipOpts.WidgetOriginHorizontal(widget.TOOLTIP_ANCHOR_END),
-				widget.ToolTipOpts.WidgetOriginVertical(widget.TOOLTIP_ANCHOR_END),
+				widget.ToolTipOpts.AnchorOriginHorizontal(widget.TOOLTIP_ANCHOR_END),
+				widget.ToolTipOpts.AnchorOriginVertical(widget.TOOLTIP_ANCHOR_END),
 				widget.ToolTipOpts.ContentOriginHorizontal(widget.TOOLTIP_ANCHOR_END),
 				widget.ToolTipOpts.ContentOriginVertical(widget.TOOLTIP_ANCHOR_START),
 			)),
@@ -208,8 +208,8 @@ func main() {
 	btn4ToolTip.Offset.Y = 0
 	btn4ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
 	btn4ToolTip.ContentOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
-	btn4ToolTip.WidgetOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
-	btn4ToolTip.WidgetOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn4ToolTip.AnchorOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn4ToolTip.AnchorOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
 	btn4ToolTip.Delay = 0
 
 	// construct a button

--- a/_examples/widget_demos/tooltips/main.go
+++ b/_examples/widget_demos/tooltips/main.go
@@ -103,7 +103,7 @@ func main() {
 	// add the button as a child of the container
 	rootContainer.AddChild(button)
 
-	//Use the NewTextToolTip convenience method to create the tooltip
+	// Use the NewTextToolTip convenience method to create the tooltip
 	btn2ToolTip := widget.NewTextToolTip("Label: 1\nLabel: 2\nLabel: 3\nLabel: 4\nLabel: 5",
 		face, color.White,
 		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
@@ -146,6 +146,54 @@ func main() {
 	)
 	// add the button2 as a child of the container
 	rootContainer.AddChild(button2)
+
+	// Use the NewTextToolTip convenience method to create the tooltip
+	btn3ToolTip := widget.NewTextToolTip("Label: 1\nLabel: 2\nLabel: 3\nLabel: 4\nLabel: 5",
+		face, color.White,
+		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
+
+	// The NewTextToolTip defaults to follow the cursor
+	// But every parameter is available to update after it has been created
+	btn3ToolTip.Position = widget.TOOLTIP_POS_SCREEN
+	btn3ToolTip.Offset.X = 200
+	btn3ToolTip.Offset.Y = 200
+	btn3ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn3ToolTip.ContentOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
+
+	// construct a button
+	button3 := widget.NewButton(
+		// set general widget options
+		widget.ButtonOpts.WidgetOpts(
+			// instruct the container's anchor layout to center the button both horizontally and vertically
+			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+				Position: widget.RowLayoutPositionCenter,
+			}),
+			widget.WidgetOpts.ToolTip(btn3ToolTip),
+		),
+
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		widget.ButtonOpts.Text("Hover for tooltip", face, &widget.ButtonTextColor{
+			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+		}),
+
+		// specify that the button's text needs some padding for correct display
+		widget.ButtonOpts.TextPadding(widget.Insets{
+			Left:   30,
+			Right:  30,
+			Top:    5,
+			Bottom: 5,
+		}),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			println("button3 clicked")
+		}),
+	)
+	// add the button2 as a child of the container
+	rootContainer.AddChild(button3)
 
 	// construct the UI
 	ui := ebitenui.UI{

--- a/_examples/widget_demos/tooltips/main.go
+++ b/_examples/widget_demos/tooltips/main.go
@@ -70,8 +70,8 @@ func main() {
 				//widget.WidgetToolTipOpts.Delay(1*time.Second),
 				widget.ToolTipOpts.Offset(img.Point{-5, 5}),
 				widget.ToolTipOpts.Position(widget.TOOLTIP_POS_WIDGET),
-				//When the Position is set to TOOLTIP_POS_WIDGET, you can configure where it opens with the optional parameters below
-				//They will default to what you see below if you do not provide them
+				// When the Position is set to TOOLTIP_POS_WIDGET, you can configure where it opens with the optional parameters below
+				// They will default to what you see below if you do not provide them
 				widget.ToolTipOpts.WidgetOriginHorizontal(widget.TOOLTIP_ANCHOR_END),
 				widget.ToolTipOpts.WidgetOriginVertical(widget.TOOLTIP_ANCHOR_END),
 				widget.ToolTipOpts.ContentOriginHorizontal(widget.TOOLTIP_ANCHOR_END),
@@ -148,7 +148,7 @@ func main() {
 	rootContainer.AddChild(button2)
 
 	// Use the NewTextToolTip convenience method to create the tooltip
-	btn3ToolTip := widget.NewTextToolTip("Label: 1\nLabel: 2\nLabel: 3\nLabel: 4\nLabel: 5",
+	btn3ToolTip := widget.NewTextToolTip("This Tooltip uses\n'widget.TOOLTIP_POS_ABSOLUTE'\nto appear always at X: 200 / Y: 100!",
 		face, color.White,
 		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
 
@@ -156,9 +156,10 @@ func main() {
 	// But every parameter is available to update after it has been created
 	btn3ToolTip.Position = widget.TOOLTIP_POS_ABSOLUTE
 	btn3ToolTip.Offset.X = 200
-	btn3ToolTip.Offset.Y = 200
+	btn3ToolTip.Offset.Y = 100
 	btn3ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
 	btn3ToolTip.ContentOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn3ToolTip.Delay = 0
 
 	// construct a button
 	button3 := widget.NewButton(
@@ -175,7 +176,7 @@ func main() {
 		widget.ButtonOpts.Image(buttonImage),
 
 		// specify the button's text, the font face, and the color
-		widget.ButtonOpts.Text("Hover for tooltip", face, &widget.ButtonTextColor{
+		widget.ButtonOpts.Text("Hover for tooltip #3", face, &widget.ButtonTextColor{
 			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
 		}),
 
@@ -194,6 +195,57 @@ func main() {
 	)
 	// add the button2 as a child of the container
 	rootContainer.AddChild(button3)
+
+	// Use the NewTextToolTip convenience method to create the tooltip
+	btn4ToolTip := widget.NewTextToolTip("This Tooltip uses\n'widget.TOOLTIP_POS_SCREEN'\nto appear always center screen!",
+		face, color.White,
+		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
+
+	// The NewTextToolTip defaults to follow the cursor
+	// But every parameter is available to update after it has been created
+	btn4ToolTip.Position = widget.TOOLTIP_POS_SCREEN
+	btn4ToolTip.Offset.X = 0
+	btn4ToolTip.Offset.Y = 0
+	btn4ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn4ToolTip.ContentOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn4ToolTip.WidgetOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn4ToolTip.WidgetOriginVertical = widget.TOOLTIP_ANCHOR_START
+	btn4ToolTip.Delay = 0
+
+	// construct a button
+	button4 := widget.NewButton(
+		// set general widget options
+		widget.ButtonOpts.WidgetOpts(
+			// instruct the container's anchor layout to center the button both horizontally and vertically
+			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+				Position: widget.RowLayoutPositionCenter,
+			}),
+			widget.WidgetOpts.ToolTip(btn4ToolTip),
+		),
+
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		widget.ButtonOpts.Text("Hover for tooltip #4", face, &widget.ButtonTextColor{
+			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+		}),
+
+		// specify that the button's text needs some padding for correct display
+		widget.ButtonOpts.TextPadding(widget.Insets{
+			Left:   30,
+			Right:  30,
+			Top:    5,
+			Bottom: 5,
+		}),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			println("button4 clicked")
+		}),
+	)
+	// add the button2 as a child of the container
+	rootContainer.AddChild(button4)
 
 	// construct the UI
 	ui := ebitenui.UI{
@@ -251,7 +303,7 @@ func loadFont(size float64) (text.Face, error) {
 	s, err := text.NewGoTextFaceSource(bytes.NewReader(goregular.TTF))
 	if err != nil {
 		log.Fatal(err)
-		return nil, err
+		return nil, fmt.Errorf("loadFont: %w", err)
 	}
 
 	return &text.GoTextFace{

--- a/_examples/widget_demos/tooltips/main.go
+++ b/_examples/widget_demos/tooltips/main.go
@@ -83,7 +83,7 @@ func main() {
 		widget.ButtonOpts.Image(buttonImage),
 
 		// specify the button's text, the font face, and the color
-		widget.ButtonOpts.Text("Hover for tooltip", face, &widget.ButtonTextColor{
+		widget.ButtonOpts.Text("Hover for tooltip #1", face, &widget.ButtonTextColor{
 			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
 		}),
 
@@ -127,7 +127,7 @@ func main() {
 		widget.ButtonOpts.Image(buttonImage),
 
 		// specify the button's text, the font face, and the color
-		widget.ButtonOpts.Text("Hover for tooltip", face, &widget.ButtonTextColor{
+		widget.ButtonOpts.Text("Hover for tooltip #2", face, &widget.ButtonTextColor{
 			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
 		}),
 
@@ -148,7 +148,7 @@ func main() {
 	rootContainer.AddChild(button2)
 
 	// Use the NewTextToolTip convenience method to create the tooltip
-	btn3ToolTip := widget.NewTextToolTip("This Tooltip uses\n'widget.TOOLTIP_POS_ABSOLUTE'\nto appear always at X: 200 / Y: 100!",
+	btn3ToolTip := widget.NewTextToolTip("This Tooltip uses\n'widget.TOOLTIP_POS_ABSOLUTE'\nto always appear at X: 200 / Y: 100!",
 		face, color.White,
 		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
 
@@ -197,7 +197,7 @@ func main() {
 	rootContainer.AddChild(button3)
 
 	// Use the NewTextToolTip convenience method to create the tooltip
-	btn4ToolTip := widget.NewTextToolTip("This Tooltip uses\n'widget.TOOLTIP_POS_SCREEN'\nto appear always center screen!",
+	btn4ToolTip := widget.NewTextToolTip("This Tooltip uses\n'widget.TOOLTIP_POS_SCREEN'\nto always appear center screen!",
 		face, color.White,
 		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
 

--- a/widget/tooltip.go
+++ b/widget/tooltip.go
@@ -22,6 +22,8 @@ const (
 	// The tooltip will display based on the Widget and Content anchor settings.
 	// It defaults to opening right aligned and directly under the widget.
 	TOOLTIP_POS_WIDGET
+	// The tooltip will display based on x/y (offset is required)
+	TOOLTIP_POS_SCREEN
 )
 
 type ToolTipAnchor int
@@ -278,10 +280,13 @@ func (t *ToolTip) showingState(p image.Point) toolTipState {
 		sx, sy := t.content.PreferredSize()
 
 		position := p
-		if t.Position == TOOLTIP_POS_CURSOR_FOLLOW {
+		switch t.Position {
+		case TOOLTIP_POS_CURSOR_FOLLOW:
 			position = cp
-		} else if t.Position == TOOLTIP_POS_WIDGET {
+		case TOOLTIP_POS_WIDGET:
 			position = t.processWidgetPosition(parent.Rect)
+		case TOOLTIP_POS_SCREEN:
+			position = image.Point{}
 		}
 		position = position.Add(t.Offset)
 		position = t.processContentPosition(position, sx, sy, parent.Rect)

--- a/widget/tooltip.go
+++ b/widget/tooltip.go
@@ -23,7 +23,7 @@ const (
 	// It defaults to opening right aligned and directly under the widget.
 	TOOLTIP_POS_WIDGET
 	// The tooltip will display based on x/y (offset is required)
-	TOOLTIP_POS_SCREEN
+	TOOLTIP_POS_ABSOLUTE
 )
 
 type ToolTipAnchor int
@@ -285,7 +285,7 @@ func (t *ToolTip) showingState(p image.Point) toolTipState {
 			position = cp
 		case TOOLTIP_POS_WIDGET:
 			position = t.processWidgetPosition(parent.Rect)
-		case TOOLTIP_POS_SCREEN:
+		case TOOLTIP_POS_ABSOLUTE:
 			position = image.Point{}
 		}
 		position = position.Add(t.Offset)

--- a/widget/tooltip.go
+++ b/widget/tooltip.go
@@ -43,9 +43,11 @@ const (
 type ToolTipDirection int
 
 type ToolTip struct {
-	Position                ToolTipPosition
-	WidgetOriginVertical    ToolTipAnchor
-	WidgetOriginHorizontal  ToolTipAnchor
+	Position ToolTipPosition
+	// WidgetOriginVertical was renamed to AnchorOriginVertical to make the it more generic and reuse it for TOOLTIP_POS_SCREEN
+	AnchorOriginVertical ToolTipAnchor
+	// WidgetOriginHorizontal was renamed to AnchorOriginHorizontal to make the it more generic and reuse it for TOOLTIP_POS_SCREEN
+	AnchorOriginHorizontal  ToolTipAnchor
 	ContentOriginVertical   ToolTipAnchor
 	ContentOriginHorizontal ToolTipAnchor
 	Delay                   time.Duration
@@ -74,8 +76,8 @@ func NewToolTip(opts ...ToolTipOpt) *ToolTip {
 		Offset: image.Point{10, 10},
 	}
 	t.state = t.idleState()
-	t.WidgetOriginHorizontal = TOOLTIP_ANCHOR_END
-	t.WidgetOriginVertical = TOOLTIP_ANCHOR_END
+	t.AnchorOriginHorizontal = TOOLTIP_ANCHOR_END
+	t.AnchorOriginVertical = TOOLTIP_ANCHOR_END
 	t.ContentOriginHorizontal = TOOLTIP_ANCHOR_END
 	t.ContentOriginVertical = TOOLTIP_ANCHOR_START
 	for _, o := range opts {
@@ -150,16 +152,16 @@ func (o ToolTipOptions) Offset(off image.Point) ToolTipOpt {
 }
 
 // The vertical position of the anchor on the widget. Only used when Postion = WIDGET.
-func (o ToolTipOptions) WidgetOriginVertical(widgetOriginVertical ToolTipAnchor) ToolTipOpt {
+func (o ToolTipOptions) AnchorOriginVertical(anchorOriginVertical ToolTipAnchor) ToolTipOpt {
 	return func(t *ToolTip) {
-		t.WidgetOriginVertical = widgetOriginVertical
+		t.AnchorOriginVertical = anchorOriginVertical
 	}
 }
 
 // The horizontal position of the anchor on the widget. Only used when Postion = WIDGET.
-func (o ToolTipOptions) WidgetOriginHorizontal(widgetOriginHorizontal ToolTipAnchor) ToolTipOpt {
+func (o ToolTipOptions) AnchorOriginHorizontal(anchorOriginHorizontal ToolTipAnchor) ToolTipOpt {
 	return func(t *ToolTip) {
-		t.WidgetOriginHorizontal = widgetOriginHorizontal
+		t.AnchorOriginHorizontal = anchorOriginHorizontal
 	}
 }
 
@@ -314,9 +316,9 @@ func (t *ToolTip) showingState(p image.Point) toolTipState {
 
 func (t *ToolTip) processWidgetPosition(widgetRect image.Rectangle) image.Point {
 	p := image.Point{}
-	switch t.WidgetOriginVertical {
+	switch t.AnchorOriginVertical {
 	case TOOLTIP_ANCHOR_START:
-		switch t.WidgetOriginHorizontal {
+		switch t.AnchorOriginHorizontal {
 		case TOOLTIP_ANCHOR_START:
 			p.X = widgetRect.Min.X
 			p.Y = widgetRect.Min.Y
@@ -328,7 +330,7 @@ func (t *ToolTip) processWidgetPosition(widgetRect image.Rectangle) image.Point 
 			p.Y = widgetRect.Min.Y
 		}
 	case TOOLTIP_ANCHOR_MIDDLE:
-		switch t.WidgetOriginHorizontal {
+		switch t.AnchorOriginHorizontal {
 		case TOOLTIP_ANCHOR_START:
 			p.X = widgetRect.Min.X
 			p.Y = widgetRect.Min.Y + (widgetRect.Dy() / 2)
@@ -340,7 +342,7 @@ func (t *ToolTip) processWidgetPosition(widgetRect image.Rectangle) image.Point 
 			p.Y = widgetRect.Min.Y + (widgetRect.Dy() / 2)
 		}
 	case TOOLTIP_ANCHOR_END:
-		switch t.WidgetOriginHorizontal {
+		switch t.AnchorOriginHorizontal {
 		case TOOLTIP_ANCHOR_START:
 			p.X = widgetRect.Min.X
 			p.Y = widgetRect.Max.Y
@@ -358,7 +360,7 @@ func (t *ToolTip) processWidgetPosition(widgetRect image.Rectangle) image.Point 
 func (t *ToolTip) processScreenPosition() image.Point {
 	windowSize := input.GetWindowSize()
 	p := image.Point{}
-	switch t.WidgetOriginHorizontal {
+	switch t.AnchorOriginHorizontal {
 	case TOOLTIP_ANCHOR_START:
 		p.X = 0
 	case TOOLTIP_ANCHOR_MIDDLE:
@@ -366,7 +368,7 @@ func (t *ToolTip) processScreenPosition() image.Point {
 	case TOOLTIP_ANCHOR_END:
 		p.X = windowSize.X
 	}
-	switch t.WidgetOriginVertical {
+	switch t.AnchorOriginVertical {
 	case TOOLTIP_ANCHOR_START:
 		p.Y = 0
 	case TOOLTIP_ANCHOR_MIDDLE:

--- a/widget/tooltip.go
+++ b/widget/tooltip.go
@@ -24,6 +24,9 @@ const (
 	TOOLTIP_POS_WIDGET
 	// The tooltip will display based on x/y (offset is required)
 	TOOLTIP_POS_ABSOLUTE
+	// The tooltip will display based on the Widget and Content anchor settings.
+	// It defaults to opening right aligned and directly under the x: 0, y: 0.
+	TOOLTIP_POS_SCREEN
 )
 
 type ToolTipAnchor int
@@ -287,6 +290,8 @@ func (t *ToolTip) showingState(p image.Point) toolTipState {
 			position = t.processWidgetPosition(parent.Rect)
 		case TOOLTIP_POS_ABSOLUTE:
 			position = image.Point{}
+		case TOOLTIP_POS_SCREEN:
+			position = t.processScreenPosition()
 		}
 		position = position.Add(t.Offset)
 		position = t.processContentPosition(position, sx, sy, parent.Rect)
@@ -350,7 +355,29 @@ func (t *ToolTip) processWidgetPosition(widgetRect image.Rectangle) image.Point 
 	return p
 }
 
-func (t *ToolTip) processContentPosition(p image.Point, sx int, sy int, widgetRect image.Rectangle) image.Point {
+func (t *ToolTip) processScreenPosition() image.Point {
+	windowSize := input.GetWindowSize()
+	p := image.Point{}
+	switch t.WidgetOriginHorizontal {
+	case TOOLTIP_ANCHOR_START:
+		p.X = 0
+	case TOOLTIP_ANCHOR_MIDDLE:
+		p.X = windowSize.X / 2
+	case TOOLTIP_ANCHOR_END:
+		p.X = windowSize.X
+	}
+	switch t.WidgetOriginVertical {
+	case TOOLTIP_ANCHOR_START:
+		p.Y = 0
+	case TOOLTIP_ANCHOR_MIDDLE:
+		p.Y = windowSize.Y / 2
+	case TOOLTIP_ANCHOR_END:
+		p.Y = windowSize.Y
+	}
+	return p
+}
+
+func (t *ToolTip) processContentPosition(p image.Point, sx, sy int, widgetRect image.Rectangle) image.Point {
 	result := processContentPositionWorker(p, sx, sy, t.ContentOriginHorizontal, t.ContentOriginVertical)
 	windowSize := input.GetWindowSize()
 	horizontalAnchor := t.ContentOriginHorizontal


### PR DESCRIPTION
Introduce 2 new "ToolTipPosition"-types:

- `TOOLTIP_POS_ABSOLUTE`. Once set, the position of the tooltip will rely on `Offset` only (ignoring cursor or widget positions).
- `TOOLTIP_POS_SCREEN`. Once set, the position of the tooltip will rely on `WidgetOriginVertical`, `WidgetOriginHorizontal`, `ContentOriginVertical` and `ContentOriginHorizontal`. E.g. setting all to `TOOLTIP_ANCHOR_MIDDLE` will make your tooltip always appear center screen.

The tooltip example is enhanced with a 3rd and 4th button to show the new options.