### PR TITLE
widget/button: Release fixed if 'ToggleMode' is on

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -688,7 +688,9 @@ func (b *Button) Release() {
 		offx /= 2
 		offy /= 2
 	}
-	b.hovering = false
+	if !b.ToggleMode {
+		b.hovering = false
+	}
 	b.widget.MouseButtonReleasedEvent.Fire(&WidgetMouseButtonReleasedEventArgs{
 		Widget:  b.widget,
 		Inside:  true,


### PR DESCRIPTION
If 'ToggleMode' was one it did a small flicker between the time the event was fired and received the button would change from pressed to idle to then pressed again