### PR TITLE
Add SelectPressed() option on lists to select entries on mouse click instead of release

### DIFF
--- a/_examples/widget_demos/list/main.go
+++ b/_examples/widget_demos/list/main.go
@@ -116,6 +116,8 @@ func main() {
 		}),
 		// This option will select the entry as it is focused
 		// widget.ListOpts.SelectFocus(),
+		// This option will select the entry when pressing the mouse button instead of releasing it
+		// widget.ListOpts.SelectPressed(),
 
 		// This option will disable default keys (up and down)
 		//widget.ListOpts.DisableDefaultKeys(true),

--- a/widget/list.go
+++ b/widget/list.go
@@ -35,6 +35,7 @@ type List struct {
 	hideVerticalSlider          bool
 	allowReselect               bool
 	selectFocus                 bool
+	selectPressed               bool
 
 	init            *MultiOnce
 	container       *Container
@@ -255,6 +256,13 @@ func (o ListOptions) AllowReselect() ListOpt {
 func (o ListOptions) SelectFocus() ListOpt {
 	return func(l *List) {
 		l.selectFocus = true
+	}
+}
+
+// SelectPressed selects entries when pressing instead of releasing (the default).
+func (o ListOptions) SelectPressed() ListOpt {
+	return func(l *List) {
+		l.selectPressed = true
 	}
 }
 
@@ -632,10 +640,14 @@ func (l *List) createEntry(entry any) *Button {
 		ButtonOpts.Text(l.entryLabelFunc(entry), l.entryFace, l.entryUnselectedTextColor),
 		ButtonOpts.TextPadding(l.entryTextPadding),
 		ButtonOpts.TextPosition(l.entryTextHorizontalPosition, l.entryTextVerticalPosition),
-		ButtonOpts.ClickedHandler(func(_ *ButtonClickedEventArgs) {
-			l.setSelectedEntry(entry, true)
-		}))
-
+	)
+	events := but.ClickedEvent
+	if l.selectPressed {
+		events = but.PressedEvent
+	}
+	events.AddHandler(func(_ interface{}) {
+		l.setSelectedEntry(entry, true)
+	})
 	return but
 }
 


### PR DESCRIPTION
Hi,

Here is a feature I’ve been using in my project, I thought that it may be considered for inclusion upstream.
Feel free to ask for any further change, or even discard the feature entirely if you don’t think it’s interesting enough.

Thanks!