### PR TITLE
Add MinSize and MaxSize Constraints to AnchorLayoutData

### DIFF
--- a/widget/anchorlayout.go
+++ b/widget/anchorlayout.go
@@ -19,6 +19,9 @@ type AnchorLayoutOpt func(a *AnchorLayout)
 type AnchorLayoutOptions struct {
 }
 
+type AnchorLayoutDataOptions struct {
+}
+
 // AnchorLayoutPosition is the type used to specify an anchoring position.
 type AnchorLayoutPosition int
 
@@ -38,6 +41,12 @@ type AnchorLayoutData struct {
 
 	// Sets the padding for the child.
 	Padding Insets
+
+	// MinSize returns the minimum size for the widget.
+	MinSize func() (int, int)
+
+	// MaxSize returns the maximum size for the widget.
+	MaxSize func() (int, int)
 }
 
 const (
@@ -54,6 +63,9 @@ const (
 // AnchorLayoutOpts contains functions that configure an AnchorLayout.
 var AnchorLayoutOpts AnchorLayoutOptions
 
+// AnchorLayoutDataOpts contains functions that configure an AnchorLayoutData.
+var AnchorLayoutDataOpts AnchorLayoutDataOptions
+
 // NewAnchorLayout constructs a new AnchorLayout, configured by opts.
 func NewAnchorLayout(opts ...AnchorLayoutOpt) *AnchorLayout {
 	a := &AnchorLayout{}
@@ -69,6 +81,20 @@ func NewAnchorLayout(opts ...AnchorLayoutOpt) *AnchorLayout {
 func (o AnchorLayoutOptions) Padding(i Insets) AnchorLayoutOpt {
 	return func(a *AnchorLayout) {
 		a.padding = i
+	}
+}
+
+// AnchorLayoutMinSize returns a function that sets the minimum size for the widget.
+func (o AnchorLayoutDataOptions) AnchorLayoutMinSize(width, height int) func() (int, int) {
+	return func() (int, int) {
+		return width, height
+	}
+}
+
+// AnchorLayoutMaxSize returns a function that sets the maximum size for the widget.
+func (o AnchorLayoutDataOptions) AnchorLayoutMaxSize(width, height int) func() (int, int) {
+	return func() (int, int) {
+		return width, height
 	}
 }
 
@@ -121,6 +147,28 @@ func (a *AnchorLayout) applyLayoutData(ld AnchorLayoutData, wx int, wy int, ww i
 
 	if ld.StretchVertical {
 		wh = rect.Dy()
+	}
+
+	// Apply minimum size constraints
+	if ld.MinSize != nil {
+		minWidth, minHeight := ld.MinSize()
+		if ww < minWidth {
+			ww = minWidth
+		}
+		if wh < minHeight {
+			wh = minHeight
+		}
+	}
+
+	// Apply maximum size constraints
+	if ld.MaxSize != nil {
+		maxWidth, maxHeight := ld.MaxSize()
+		if ww > maxWidth {
+			ww = maxWidth
+		}
+		if wh > maxHeight {
+			wh = maxHeight
+		}
 	}
 
 	hPos := ld.HorizontalPosition


### PR DESCRIPTION
This PR adds MinSize and MaxSize to AnchorLayoutData, making it easier to define size constraints directly within the layout data.

Why?
I was discussing this with a friend, and we both found the current way a bit unintuitive to set the minSize in the widget options. When trying to set min/max sizes, we instinctively looked for those properties in AnchorLayoutData, not in WidgetOpts. Having to set MinSize separately on the widget felt disconnected from the layout itself.

With this change, you can now define MinSize and MaxSize directly in AnchorLayoutData, making it more natural to work with:

Before (current way, still works):
```go
innerContainer := widget.NewContainer(
	widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{255, 0, 0, 255})),
	widget.ContainerOpts.WidgetOpts(
		widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
			HorizontalPosition: widget.AnchorLayoutPositionCenter,
			VerticalPosition:   widget.AnchorLayoutPositionCenter,
			StretchHorizontal:  true,
			StretchVertical:    false,
		}),
		widget.WidgetOpts.MinSize(100, 100), 
	),
)
```

After (my change, I think is look more intuitive):
```go
innerContainer := widget.NewContainer(
	widget.ContainerOpts.BackgroundImage(image.NewNineSliceColor(color.NRGBA{255, 0, 0, 255})),
	widget.ContainerOpts.WidgetOpts(
		widget.WidgetOpts.LayoutData(widget.AnchorLayoutData{
			HorizontalPosition: widget.AnchorLayoutPositionCenter,
			VerticalPosition:   widget.AnchorLayoutPositionCenter,
			StretchHorizontal:  true,
			StretchVertical:    false,
			MinSize:            widget.AnchorLayoutDataOpts.AnchorLayoutMinSize(100, 100),
			MaxSize:            widget.AnchorLayoutDataOpts.AnchorLayoutMaxSize(300, 300),
		}),
	),
)
```
With min size:
![image](https://github.com/user-attachments/assets/60e31b50-58ff-44b4-a503-4db5e82408e5)

With min and max size:
![image](https://github.com/user-attachments/assets/ba596384-cf90-4990-bbc5-8c6e48409093)

Important: 

The old way still works—this just adds an alternative way to set size constraints directly in the layout.

MaxSize didn’t exist before, so this also introduces a way to cap widget sizes inside AnchorLayout.

This should make it easier to reason about layout constraints while keeping everything backward-compatible.