### PR TITLE
Remove deprecated size call

### DIFF
--- a/image/buffer.go
+++ b/image/buffer.go
@@ -25,7 +25,7 @@ type DrawFunc func(buf *ebiten.Image)
 func (b *BufferedImage) Image() *ebiten.Image {
 	w, h := -1, -1
 	if b.image != nil {
-		w, h = b.image.Size()
+		w, h = b.image.Bounds().Dx(), b.image.Bounds().Dy()
 	}
 
 	if b.image == nil || b.Width != w || b.Height != h {

--- a/image/nineslice.go
+++ b/image/nineslice.go
@@ -195,7 +195,7 @@ func (n *NineSlice) centerOnly() bool {
 		return false
 	}
 
-	w, h := n.image.Size()
+	w, h := n.image.Bounds().Dx(), n.image.Bounds().Dy()
 	return n.widths[1] == w && n.heights[1] == h
 }
 


### PR DESCRIPTION
Simple change these calls are deprecated, call Bounds().Dx(), Bounds().Dy() instead