### PR TITLE
Fix Grid Crash

### DIFF
--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -154,7 +154,7 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 		if w.GetWidget().Visibility == Visibility_Hide {
 			nextColumn()
 			continue
-		} else if w.GetWidget().Visibility == Visibility_Hide {
+		} else if w.GetWidget().Visibility == Visibility_Hide_Blocking {
 			x += cw + g.columnSpacing
 			nextColumn()
 			continue

--- a/widget/gridlayout.go
+++ b/widget/gridlayout.go
@@ -134,15 +134,29 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 
 	c, r := 0, 0
 	x, y := 0, 0
+	var ch int
 	firstStretchedCol, firstStretchedRow := true, true
+
+	// Anytime c is incremented, call this
+	nextColumn := func() {
+		c++
+		if c >= g.columns {
+			c = 0
+			r++
+			x = 0
+			y += ch + g.rowSpacing
+			firstStretchedCol = true
+		}
+	}
+
 	for _, w := range widgets {
 		cw := colWidths[c]
 		if w.GetWidget().Visibility == Visibility_Hide {
-			c++
+			nextColumn()
 			continue
 		} else if w.GetWidget().Visibility == Visibility_Hide {
-			c++
 			x += cw + g.columnSpacing
+			nextColumn()
 			continue
 		}
 
@@ -154,7 +168,7 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 			}
 		}
 
-		ch := rowHeights[r]
+		ch = rowHeights[r]
 		if g.rowStretched(r) {
 			ch = stretchedRowHeight
 			if firstStretchedRow {
@@ -173,16 +187,8 @@ func (g *GridLayout) Layout(widgets []PreferredSizeLocateableWidget, rect image.
 
 		w.SetLocation(image.Rect(rect.Min.X+wx, rect.Min.Y+wy, rect.Min.X+wx+ww, rect.Min.Y+wy+wh))
 
-		c++
+		nextColumn()
 		x += cw + g.columnSpacing
-
-		if c >= g.columns {
-			c = 0
-			r++
-			x = 0
-			y += ch + g.rowSpacing
-			firstStretchedCol = true
-		}
 	}
 }
 


### PR DESCRIPTION
I noticed that hidden elements can cause c to be incremented above the size of colWidths, which can cause the first line of the for loop to crash:

`cw := colWidths[c]`

This seems to fix it in my case. I'm open to suggestions on a more appropriate way to fix this.