### PR TITLE
Request relayout once when adding multiple children

### DIFF
--- a/widget/container.go
+++ b/widget/container.go
@@ -112,8 +112,8 @@ func (c *Container) AddChild(children ...PreferredSizeLocateableWidget) RemoveCh
 				c.GetWidget().FireDragAndDropEvent(a.Window, a.Show, a.DnD)
 			}
 		})
-		c.RequestRelayout()
 	}
+	c.RequestRelayout()
 
 	return func() {
 		for _, child := range children {


### PR DESCRIPTION
I was playing with creating a table with columns and lots of lines (think thousands of widgets added to a grid container), and noticed that creating the table seemed really slow. It seems due at least partly to the relayout when adding the widgets to the container. I think when adding multiple widgets we can relayout only once (that’s what the `RemoveChildren()` does anyway).
It won’t solve all my current performance problems, but it’s a start 😄 