### PR TITLE
dont request a relayout when location is updated

### DIFF
--- a/widget/container.go
+++ b/widget/container.go
@@ -230,7 +230,10 @@ func (c *Container) PreferredSize() (int, int) {
 
 func (c *Container) SetLocation(rect img.Rectangle) {
 	c.init.Do()
-	c.widget.Rect = rect
+	if c.widget.Rect != rect {
+		c.widget.Rect = rect
+		c.RequestRelayout()
+	}
 }
 
 func (c *Container) Render(screen *ebiten.Image) {

--- a/widget/container.go
+++ b/widget/container.go
@@ -231,7 +231,6 @@ func (c *Container) PreferredSize() (int, int) {
 func (c *Container) SetLocation(rect img.Rectangle) {
 	c.init.Do()
 	c.widget.Rect = rect
-	c.RequestRelayout()
 }
 
 func (c *Container) Render(screen *ebiten.Image) {


### PR DESCRIPTION
When a scroll container has its position updated, it eventually invokes c.SetLocation() on the underlying contents, which causes a relayout of the contents. The relayout call can be removed because it is unnecessary, and causes a substantial amount of work to be done.