### PR TITLE
container must invoke relayout on parent

### DIFF
--- a/widget/container.go
+++ b/widget/container.go
@@ -18,7 +18,7 @@ type Container struct {
 	layout      Layouter
 	layoutDirty bool
 
-    parentLayout Relayoutable
+	parentLayout Relayoutable
 
 	init     *MultiOnce
 	widget   *Widget
@@ -82,7 +82,7 @@ func (o ContainerOptions) Layout(layout Layouter) ContainerOpt {
 }
 
 func (c *Container) SetParentLayout(parent Relayoutable) {
-    c.parentLayout = parent
+	c.parentLayout = parent
 }
 
 func (c *Container) AddChild(children ...PreferredSizeLocateableWidget) RemoveChildFunc {
@@ -96,8 +96,8 @@ func (c *Container) AddChild(children ...PreferredSizeLocateableWidget) RemoveCh
 		c.children = append(c.children, child)
 
 		if r, ok := child.(Relayoutable); ok {
-            r.SetParentLayout(c)
-        }
+			r.SetParentLayout(c)
+		}
 
 		child.GetWidget().parent = c.widget
 		child.GetWidget().self = child
@@ -124,9 +124,9 @@ func (c *Container) AddChild(children ...PreferredSizeLocateableWidget) RemoveCh
 		})
 	}
 
-    if c.parentLayout != nil {
-        c.parentLayout.RequestRelayout()
-    }
+	if c.parentLayout != nil {
+		c.parentLayout.RequestRelayout()
+	}
 
 	c.RequestRelayout()
 
@@ -166,9 +166,9 @@ func (c *Container) RemoveChild(child PreferredSizeLocateableWidget) {
 		child.GetWidget().ContextMenuWindow.Close()
 	}
 
-    if c.parentLayout != nil {
-        c.parentLayout.RequestRelayout()
-    }
+	if c.parentLayout != nil {
+		c.parentLayout.RequestRelayout()
+	}
 
 	c.RequestRelayout()
 }
@@ -192,9 +192,9 @@ func (c *Container) RemoveChildren() {
 	}
 	c.children = nil
 
-    if c.parentLayout != nil {
-        c.parentLayout.RequestRelayout()
-    }
+	if c.parentLayout != nil {
+		c.parentLayout.RequestRelayout()
+	}
 
 	c.RequestRelayout()
 }

--- a/widget/container.go
+++ b/widget/container.go
@@ -154,6 +154,10 @@ func (c *Container) RemoveChild(child PreferredSizeLocateableWidget) {
 
 	child.GetWidget().parent = nil
 
+	if r, ok := child.(Relayoutable); ok {
+		r.SetParentLayout(nil)
+	}
+
 	if child.GetWidget().ToolTip != nil && child.GetWidget().ToolTip.window != nil {
 		child.GetWidget().ToolTip.window.Close()
 	}
@@ -177,6 +181,10 @@ func (c *Container) RemoveChildren() {
 	for i := range c.children {
 		childWidget := c.children[i].GetWidget()
 		childWidget.parent = nil
+
+		if r, ok := c.children[i].(Relayoutable); ok {
+			r.SetParentLayout(nil)
+		}
 
 		if childWidget.ToolTip != nil && childWidget.ToolTip.window != nil {
 			childWidget.ToolTip.window.Close()

--- a/widget/layout.go
+++ b/widget/layout.go
@@ -11,7 +11,7 @@ type Layouter interface {
 
 type Relayoutable interface {
 	RequestRelayout()
-    SetParentLayout(Relayoutable)
+	SetParentLayout(Relayoutable)
 }
 
 type Locateable interface {

--- a/widget/layout.go
+++ b/widget/layout.go
@@ -11,6 +11,7 @@ type Layouter interface {
 
 type Relayoutable interface {
 	RequestRelayout()
+    SetParentLayout(Relayoutable)
 }
 
 type Locateable interface {

--- a/widget/list.go
+++ b/widget/list.go
@@ -287,6 +287,9 @@ func (l *List) SetLocation(rect img.Rectangle) {
 	l.container.GetWidget().Rect = rect
 }
 
+func (l *List) SetParentLayout(parent Relayoutable) {
+}
+
 func (l *List) RequestRelayout() {
 	l.init.Do()
 	l.container.RequestRelayout()
@@ -699,3 +702,5 @@ func scrollClamp(targetScroll, currentScroll float64) float64 {
 	maxScroll := currentScroll + maxScrollStep
 	return math.Max(minScroll, math.Min(targetScroll, maxScroll))
 }
+
+var _ Relayoutable = &List{}


### PR DESCRIPTION
If a child is removed or added to a container, the container's size might change and thus the parent of that container should perform a layout. There is currently no way for a child container to request a relayout from a parent container. This PR adds a new field to container that holds a parent relayoutable object, such that when AddChild or RemoveChild is called on the container, the a relayout is also requested on the parent.