### PR TITLE
Adds support for Button pressed disabled image

### DIFF
--- a/widget/button.go
+++ b/widget/button.go
@@ -741,7 +741,7 @@ func (b *Button) draw(screen *ebiten.Image) {
 				i = b.computedParams.Image.Hover
 			}
 		}
-	case pressed || b.justSubmitted:
+	case pressed, b.justSubmitted:
 		if b.computedParams.Image.Pressed != nil {
 			i = b.computedParams.Image.Pressed
 		}

--- a/widget/button.go
+++ b/widget/button.go
@@ -724,7 +724,7 @@ func (b *Button) draw(screen *ebiten.Image) {
 		}
 
 	case b.focused, b.hovering:
-		if b.ToggleMode && b.state == WidgetChecked || b.pressing && (b.hovering || b.KeepPressedOnExit) {
+		if b.pressing && (b.hovering || b.KeepPressedOnExit) || b.ToggleMode && b.state == WidgetChecked {
 			if b.computedParams.Image.PressedHover != nil {
 				i = b.computedParams.Image.PressedHover
 			} else {

--- a/widget/button.go
+++ b/widget/button.go
@@ -67,11 +67,12 @@ type Button struct {
 type ButtonOpt func(b *Button)
 
 type ButtonImage struct {
-	Idle         *image.NineSlice
-	Hover        *image.NineSlice
-	Pressed      *image.NineSlice
-	PressedHover *image.NineSlice
-	Disabled     *image.NineSlice
+	Idle            *image.NineSlice
+	Hover           *image.NineSlice
+	Pressed         *image.NineSlice
+	PressedHover    *image.NineSlice
+	Disabled        *image.NineSlice
+	PressedDisabled *image.NineSlice
 }
 
 type ButtonTextColor struct {
@@ -722,7 +723,11 @@ func (b *Button) draw(screen *ebiten.Image) {
 		if b.computedParams.Image.Disabled != nil {
 			i = b.computedParams.Image.Disabled
 		}
-
+		if b.pressing && (b.hovering || b.KeepPressedOnExit) || b.ToggleMode && b.state == WidgetChecked {
+			if b.computedParams.Image.PressedDisabled != nil {
+				i = b.computedParams.Image.PressedDisabled
+			}
+		}
 	case b.focused, b.hovering:
 		if b.pressing && (b.hovering || b.KeepPressedOnExit) || b.ToggleMode && b.state == WidgetChecked {
 			if b.computedParams.Image.PressedHover != nil {

--- a/widget/button.go
+++ b/widget/button.go
@@ -718,18 +718,19 @@ func (b *Button) Update(updObj *UpdateObject) {
 
 func (b *Button) draw(screen *ebiten.Image) {
 	i := b.computedParams.Image.Idle
+	pressed := b.pressing && (b.hovering || b.KeepPressedOnExit) || b.ToggleMode && b.state == WidgetChecked
 	switch {
 	case b.widget.Disabled:
 		if b.computedParams.Image.Disabled != nil {
 			i = b.computedParams.Image.Disabled
 		}
-		if b.pressing && (b.hovering || b.KeepPressedOnExit) || b.ToggleMode && b.state == WidgetChecked {
+		if pressed {
 			if b.computedParams.Image.PressedDisabled != nil {
 				i = b.computedParams.Image.PressedDisabled
 			}
 		}
 	case b.focused, b.hovering:
-		if b.pressing && (b.hovering || b.KeepPressedOnExit) || b.ToggleMode && b.state == WidgetChecked {
+		if pressed {
 			if b.computedParams.Image.PressedHover != nil {
 				i = b.computedParams.Image.PressedHover
 			} else {
@@ -740,7 +741,7 @@ func (b *Button) draw(screen *ebiten.Image) {
 				i = b.computedParams.Image.Hover
 			}
 		}
-	case b.pressing && (b.hovering || b.KeepPressedOnExit) || (b.ToggleMode && b.state == WidgetChecked) || b.justSubmitted:
+	case pressed || b.justSubmitted:
 		if b.computedParams.Image.Pressed != nil {
 			i = b.computedParams.Image.Pressed
 		}

--- a/widget/button.go
+++ b/widget/button.go
@@ -718,7 +718,7 @@ func (b *Button) Update(updObj *UpdateObject) {
 
 func (b *Button) draw(screen *ebiten.Image) {
 	i := b.computedParams.Image.Idle
-	pressed := b.pressing && (b.hovering || b.KeepPressedOnExit) || b.ToggleMode && b.state == WidgetChecked
+	pressed := (b.pressing && (b.hovering || b.KeepPressedOnExit)) || (b.ToggleMode && b.state == WidgetChecked)
 	switch {
 	case b.widget.Disabled:
 		if b.computedParams.Image.Disabled != nil {


### PR DESCRIPTION
The use case is when we have buttons with `widget.ButtonOpts.ToggleMode()` or for which the state is manually changed.
When the UI gets disabled, we may want to distinguish between checked and unchecked buttons.
For instance the TabBook may benefit for this.

Best reviewed commit by commit.