### PR TITLE
ToolTip: Multiple ones possible and KeepOnHover option

### DIFF
--- a/_examples/demo/page.go
+++ b/_examples/demo/page.go
@@ -624,11 +624,11 @@ func toolTipPage(res *uiResources) *page {
 		children := bc.Children()
 		for i := range children {
 			if args.State == widget.WidgetChecked {
-				children[i].GetWidget().ToolTip.Delay = 800 * time.Millisecond
-				children[i].GetWidget().ToolTip.Position = widget.TOOLTIP_POS_CURSOR_STICKY
+				children[i].GetWidget().ToolTips[0].Delay = 800 * time.Millisecond
+				children[i].GetWidget().ToolTips[0].Position = widget.TOOLTIP_POS_CURSOR_STICKY
 			} else {
-				children[i].GetWidget().ToolTip.Delay = 0
-				children[i].GetWidget().ToolTip.Position = widget.TOOLTIP_POS_CURSOR_FOLLOW
+				children[i].GetWidget().ToolTips[0].Delay = 0
+				children[i].GetWidget().ToolTips[0].Position = widget.TOOLTIP_POS_CURSOR_FOLLOW
 			}
 		}
 	}, res)

--- a/_examples/widget_demos/tooltips/main.go
+++ b/_examples/widget_demos/tooltips/main.go
@@ -244,8 +244,74 @@ func main() {
 			println("button4 clicked")
 		}),
 	)
+
+	btn5_1ToolTip := widget.NewTextToolTip("Multiple ToolTip(1)!",
+		&face, color.White,
+		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
+
+	// The NewTextToolTip defaults to follow the cursor
+	// But every parameter is available to update after it has been created
+	btn5_1ToolTip.Position = widget.TOOLTIP_POS_WIDGET
+	btn5_1ToolTip.Offset = img.Point{15, -45}
+	btn5_1ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_END
+	btn5_1ToolTip.ContentOriginVertical = widget.TOOLTIP_ANCHOR_START
+	btn5_1ToolTip.AnchorOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn5_1ToolTip.AnchorOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn5_1ToolTip.Delay = 0
+
+	btn5_2ToolTip := widget.NewTextToolTip("M(2)-Hover me!",
+		&face, color.White,
+		image.NewNineSliceColor(color.NRGBA{R: 170, G: 170, B: 230, A: 255}))
+
+	// The NewTextToolTip defaults to follow the cursor
+	// But every parameter is available to update after it has been created
+	btn5_2ToolTip.Position = widget.TOOLTIP_POS_WIDGET
+	btn5_2ToolTip.Offset = img.Point{15, 15}
+	btn5_2ToolTip.ContentOriginHorizontal = widget.TOOLTIP_ANCHOR_END
+	btn5_2ToolTip.ContentOriginVertical = widget.TOOLTIP_ANCHOR_START
+	btn5_2ToolTip.AnchorOriginHorizontal = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn5_2ToolTip.AnchorOriginVertical = widget.TOOLTIP_ANCHOR_MIDDLE
+	btn5_2ToolTip.Delay = 0
+	btn5_2ToolTip.KeepOnHover = true
+
+	button5 := widget.NewButton(
+		// set general widget options
+		widget.ButtonOpts.WidgetOpts(
+			// instruct the container's anchor layout to center the button both horizontally and vertically
+			widget.WidgetOpts.LayoutData(widget.RowLayoutData{
+				Position: widget.RowLayoutPositionCenter,
+			}),
+			widget.WidgetOpts.ToolTip(btn5_1ToolTip, btn5_2ToolTip),
+			//widget.WidgetOpts.ToolTip(btn5_1ToolTip),
+		),
+
+		// specify the images to use
+		widget.ButtonOpts.Image(buttonImage),
+
+		// specify the button's text, the font face, and the color
+		widget.ButtonOpts.Text("Hover for tooltip #5", &face, &widget.ButtonTextColor{
+			Idle: color.NRGBA{0xdf, 0xf4, 0xff, 0xff},
+		}),
+
+		// specify that the button's text needs some padding for correct display
+		widget.ButtonOpts.TextPadding(&widget.Insets{
+			Left:   30,
+			Right:  30,
+			Top:    5,
+			Bottom: 5,
+		}),
+
+		// add a handler that reacts to clicking the button
+		widget.ButtonOpts.ClickedHandler(func(args *widget.ButtonClickedEventArgs) {
+			println("button5 clicked")
+		}),
+	)
+
 	// add the button2 as a child of the container
-	rootContainer.AddChild(button4)
+	rootContainer.AddChild(
+		button4,
+		button5,
+	)
 
 	// construct the UI
 	ui := ebitenui.UI{

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -115,7 +115,7 @@ type Widget struct {
 	ContextMenuWindow    *Window
 	ContextMenuCloseMode WindowCloseMode
 
-	ToolTip *ToolTip
+	ToolTips []*ToolTip
 
 	DragAndDrop *DragAndDrop
 
@@ -523,12 +523,17 @@ func (o WidgetOptions) ContextMenuCloseMode(contextMenuCloseMode WindowCloseMode
 	}
 }
 
-func (o WidgetOptions) ToolTip(toolTip *ToolTip) WidgetOpt {
+func (o WidgetOptions) ToolTip(toolTips ...*ToolTip) WidgetOpt {
 	return func(w *Widget) {
-		w.ToolTip = toolTip
-		if w.ToolTip != nil {
-			if w.ToolTip.window != nil {
-				w.ToolTip.window.container.GetWidget().parent = w
+		for _, tt := range toolTips {
+			if w.ToolTips == nil {
+				w.ToolTips = make([]*ToolTip, 0, 0)
+			}
+			if tt != nil {
+				w.ToolTips = append(w.ToolTips, tt)
+				if tt.window != nil {
+					tt.window.container.GetWidget().parent = w
+				}
 			}
 		}
 	}
@@ -637,8 +642,8 @@ func (w *Widget) Update(updObj *UpdateObject) {
 	if w.DragAndDrop != nil {
 		w.DragAndDrop.Update(w.self)
 	}
-	if w.ToolTip != nil {
-		w.ToolTip.Update(w)
+	for _, t := range w.ToolTips {
+		t.Update(w)
 	}
 	if w.OnUpdate != nil {
 		w.OnUpdate(w.self)


### PR DESCRIPTION
This changes allow for a Widget to have multiple ToolTips at once and also added a new option `KeepOnHover(bool)` to keep the ToolTip open when the cursor is hovering it

This introduces a breaking change as the `Widget.Tooltip` was a `*ToolTip` and now it's a `[]*ToolTip`. I could also name it `ToolTips` to be more cohesive as we are already introducing a breaking change :shrug: 

Closes #300 