### PR TITLE
widget/container: Make the 'RemoveChild/ren' cascade effect

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -98,6 +98,9 @@ func (u *UI) Update() {
 	if u.updObj.RelayoutRequested {
 		u.Container.RequestRelayout()
 	}
+	if u.updObj.CloseEphemeralWindows {
+		u.closeEphemeralWindows(0)
+	}
 	for ; index < len(u.windows); index++ {
 		u.resetUpdateObject()
 		u.windows[index].Update(u.updObj)
@@ -125,6 +128,7 @@ func (u *UI) resetUpdateObject() {
 		u.updObj = &widget.UpdateObject{}
 	} else {
 		u.updObj.RelayoutRequested = false
+		u.updObj.CloseEphemeralWindows = false
 	}
 }
 

--- a/widget/container.go
+++ b/widget/container.go
@@ -15,11 +15,13 @@ type Container struct {
 	computedParams      PanelParams
 	AutoDisableChildren bool
 
-	widgetOpts     []WidgetOpt
-	layout         Layouter
-	layoutDirty    bool
-	relayoutParent bool
-	validated      bool
+	widgetOpts  []WidgetOpt
+	layout      Layouter
+	layoutDirty bool
+	validated   bool
+
+	relayoutParent        bool
+	closeEphemeralWindows bool
 
 	init     *MultiOnce
 	widget   *Widget
@@ -147,18 +149,6 @@ func (c *Container) ReplaceChild(remove PreferredSizeLocateableWidget, add Prefe
 
 func closeWidget(w *Widget) {
 	w.parent = nil
-
-	if w.ToolTip != nil && w.ToolTip.window != nil {
-		w.ToolTip.window.Close()
-	}
-
-	if w.DragAndDrop != nil && w.DragAndDrop.window != nil {
-		w.DragAndDrop.window.Close()
-	}
-
-	if w.ContextMenuWindow != nil {
-		w.ContextMenuWindow.Close()
-	}
 }
 
 func (c *Container) RemoveChild(child PreferredSizeLocateableWidget) {
@@ -180,6 +170,7 @@ func (c *Container) RemoveChild(child PreferredSizeLocateableWidget) {
 
 	c.RequestRelayout()
 	c.relayoutParent = true
+	c.closeEphemeralWindows = true
 }
 
 func (c *Container) RemoveChildren() {
@@ -190,6 +181,7 @@ func (c *Container) RemoveChildren() {
 
 	c.RequestRelayout()
 	c.relayoutParent = true
+	c.closeEphemeralWindows = true
 }
 
 func (c *Container) Children() []PreferredSizeLocateableWidget {
@@ -317,6 +309,10 @@ func (c *Container) Update(updObj *UpdateObject) {
 	if c.relayoutParent {
 		updObj.RelayoutRequested = updObj.RelayoutRequested || true
 		c.relayoutParent = false
+	}
+	if c.closeEphemeralWindows {
+		updObj.CloseEphemeralWindows = updObj.CloseEphemeralWindows || true
+		c.closeEphemeralWindows = false
 	}
 }
 

--- a/widget/widget.go
+++ b/widget/widget.go
@@ -138,7 +138,8 @@ type Renderer interface {
 }
 
 type UpdateObject struct {
-	RelayoutRequested bool
+	RelayoutRequested     bool
+	CloseEphemeralWindows bool
 }
 
 // Updater may be implemented by concrete widget types that should be updated.


### PR DESCRIPTION
So any of the childrens of them also call the function as long as they are containers.

This way all the containers are properly cleaned up

Closes #303 