### PR TITLE
tab book: support images in tabs

### DIFF
--- a/_examples/demo/page.go
+++ b/_examples/demo/page.go
@@ -306,10 +306,11 @@ func tabBookPage(res *uiResources) *page {
 
 	for i := 0; i < 4; i++ {
 		tab := widget.NewTabBookTab(fmt.Sprintf("Tab %d", i+1),
-			widget.ContainerOpts.Layout(widget.NewRowLayout(
-				widget.RowLayoutOpts.Direction(widget.DirectionVertical),
-				widget.RowLayoutOpts.Spacing(10))),
-			widget.ContainerOpts.AutoDisableChildren())
+			widget.TabBookTabOpts.ContainerOpts(
+				widget.ContainerOpts.Layout(widget.NewRowLayout(
+					widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+					widget.RowLayoutOpts.Spacing(10))),
+				widget.ContainerOpts.AutoDisableChildren()))
 
 		for j := 0; j < 3; j++ {
 			b := widget.NewButton(

--- a/_examples/demo/page.go
+++ b/_examples/demo/page.go
@@ -305,7 +305,7 @@ func tabBookPage(res *uiResources) *page {
 	tabs := []*widget.TabBookTab{}
 
 	for i := 0; i < 4; i++ {
-		tab := widget.NewTabBookTab(fmt.Sprintf("Tab %d", i+1),
+		tab := widget.NewTabBookTab(widget.TabBookTabOpts.Label(fmt.Sprintf("Tab %d", i+1)),
 			widget.TabBookTabOpts.ContainerOpts(
 				widget.ContainerOpts.Layout(widget.NewRowLayout(
 					widget.RowLayoutOpts.Direction(widget.DirectionVertical),

--- a/_examples/widget_demos/tabbook/main.go
+++ b/_examples/widget_demos/tabbook/main.go
@@ -44,7 +44,8 @@ func main() {
 
 	// Create the first tab
 	// A TabBookTab is a labelled container. The text here is what will show up in the tab button
-	game.TabRed = widget.NewTabBookTab("Red Tab",
+	game.TabRed = widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Red Tab"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{255, 0, 0, 255})),
 			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
@@ -60,7 +61,8 @@ func main() {
 	)
 	game.TabRed.AddChild(redBtn)
 
-	game.TabGreen = widget.NewTabBookTab("Green Tab",
+	game.TabGreen = widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Green Tab"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{0, 255, 0, 0xff})),
 			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
@@ -79,7 +81,8 @@ func main() {
 	blueImage := ebiten.NewImage(10, 10)
 	blueImage.Fill(color.NRGBA{0, 0, 255, 255})
 
-	game.TabBlue = widget.NewTabBookTab("Blue Tab",
+	game.TabBlue = widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Blue Tab"),
 		widget.TabBookTabOpts.Image(&widget.GraphicImage{
 			Idle: blueImage,
 			Disabled: blueImage,
@@ -109,7 +112,8 @@ func main() {
 	)
 	game.TabBlue.AddChild(blueBtn2)
 
-	tabDisabled := widget.NewTabBookTab("Disabled Tab",
+	tabDisabled := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Disabled Tab"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{R: 80, G: 80, B: 140, A: 255})),
 		),

--- a/_examples/widget_demos/tabbook/main.go
+++ b/_examples/widget_demos/tabbook/main.go
@@ -45,8 +45,10 @@ func main() {
 	// Create the first tab
 	// A TabBookTab is a labelled container. The text here is what will show up in the tab button
 	game.TabRed = widget.NewTabBookTab("Red Tab",
-		widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{255, 0, 0, 255})),
-		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{255, 0, 0, 255})),
+			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		),
 	)
 
 	redBtn := widget.NewText(
@@ -59,8 +61,10 @@ func main() {
 	game.TabRed.AddChild(redBtn)
 
 	game.TabGreen = widget.NewTabBookTab("Green Tab",
-		widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{0, 255, 0, 0xff})),
-		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{0, 255, 0, 0xff})),
+			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		),
 	)
 	greenBtn := widget.NewText(
 		widget.TextOpts.Text("Green Tab Button\nThis is configured as the initial tab.\nPress 'G' to select this tab.", &face, color.Black),
@@ -72,12 +76,23 @@ func main() {
 	)
 	game.TabGreen.AddChild(greenBtn)
 
+	blueImage := ebiten.NewImage(10, 10)
+	blueImage.Fill(color.NRGBA{0, 0, 255, 255})
+
 	game.TabBlue = widget.NewTabBookTab("Blue Tab",
-		widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{0, 0, 255, 0xff})),
-		widget.ContainerOpts.Layout(widget.NewRowLayout(
-			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
-			widget.RowLayoutOpts.Spacing(5),
-		)),
+		widget.TabBookTabOpts.Image(&widget.GraphicImage{
+			Idle: blueImage,
+			Disabled: blueImage,
+			Pressed: blueImage,
+			Hover: blueImage,
+		}),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{0, 0, 255, 0xff})),
+			widget.ContainerOpts.Layout(widget.NewRowLayout(
+				widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+				widget.RowLayoutOpts.Spacing(5),
+			)),
+		),
 	)
 	blueBtn1 := widget.NewText(
 		widget.TextOpts.Text("Blue Tab Button 1", &face, color.White),
@@ -95,7 +110,9 @@ func main() {
 	game.TabBlue.AddChild(blueBtn2)
 
 	tabDisabled := widget.NewTabBookTab("Disabled Tab",
-		widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{R: 80, G: 80, B: 140, A: 255})),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.BackgroundImage(e_image.NewNineSliceColor(color.NRGBA{R: 80, G: 80, B: 140, A: 255})),
+		),
 	)
 	tabDisabled.Disabled = true
 	game.TabBook = widget.NewTabBook(

--- a/_examples/widget_demos/theming/tabs/button_tab.go
+++ b/_examples/widget_demos/theming/tabs/button_tab.go
@@ -5,7 +5,8 @@ import (
 )
 
 func NewButtonTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Button",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Button"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
 		),

--- a/_examples/widget_demos/theming/tabs/button_tab.go
+++ b/_examples/widget_demos/theming/tabs/button_tab.go
@@ -6,7 +6,9 @@ import (
 
 func NewButtonTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Button",
-		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		),
 	)
 	var button *widget.Button
 	button = widget.NewButton(

--- a/_examples/widget_demos/theming/tabs/checkbox_tab.go
+++ b/_examples/widget_demos/theming/tabs/checkbox_tab.go
@@ -7,7 +7,8 @@ import (
 )
 
 func NewCheckboxTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Checkbox",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Checkbox"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(
 				widget.NewRowLayout(

--- a/_examples/widget_demos/theming/tabs/checkbox_tab.go
+++ b/_examples/widget_demos/theming/tabs/checkbox_tab.go
@@ -8,11 +8,13 @@ import (
 
 func NewCheckboxTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Checkbox",
-		widget.ContainerOpts.Layout(
-			widget.NewRowLayout(
-				widget.RowLayoutOpts.Direction(widget.DirectionVertical),
-				widget.RowLayoutOpts.Spacing(35),
-				widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(30)),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(
+				widget.NewRowLayout(
+					widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+					widget.RowLayoutOpts.Spacing(35),
+					widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(30)),
+				),
 			),
 		),
 	)

--- a/_examples/widget_demos/theming/tabs/label_tab.go
+++ b/_examples/widget_demos/theming/tabs/label_tab.go
@@ -6,11 +6,13 @@ import (
 
 func NewLabelTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Label",
-		widget.ContainerOpts.Layout(widget.NewRowLayout(
-			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
-			widget.RowLayoutOpts.Spacing(10),
-			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(20)),
-		)),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewRowLayout(
+				widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+				widget.RowLayoutOpts.Spacing(10),
+				widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(20)),
+			)),
+		),
 	)
 
 	/**

--- a/_examples/widget_demos/theming/tabs/label_tab.go
+++ b/_examples/widget_demos/theming/tabs/label_tab.go
@@ -5,7 +5,8 @@ import (
 )
 
 func NewLabelTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Label",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Label"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewRowLayout(
 				widget.RowLayoutOpts.Direction(widget.DirectionVertical),

--- a/_examples/widget_demos/theming/tabs/list_tab.go
+++ b/_examples/widget_demos/theming/tabs/list_tab.go
@@ -12,7 +12,8 @@ type ListEntry struct {
 }
 
 func NewListTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("List",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("List"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
 		),

--- a/_examples/widget_demos/theming/tabs/list_tab.go
+++ b/_examples/widget_demos/theming/tabs/list_tab.go
@@ -13,7 +13,9 @@ type ListEntry struct {
 
 func NewListTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("List",
-		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		),
 	)
 	// Create array of list entries
 	numEntries := 20

--- a/_examples/widget_demos/theming/tabs/progressbar_tab.go
+++ b/_examples/widget_demos/theming/tabs/progressbar_tab.go
@@ -8,7 +8,8 @@ import (
 )
 
 func NewProgressBarTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Progress Bar",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Progress Bar"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
 		),

--- a/_examples/widget_demos/theming/tabs/progressbar_tab.go
+++ b/_examples/widget_demos/theming/tabs/progressbar_tab.go
@@ -9,7 +9,9 @@ import (
 
 func NewProgressBarTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Progress Bar",
-		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		),
 	)
 
 	// Construct a container to hold the progress bars.

--- a/_examples/widget_demos/theming/tabs/select_tab.go
+++ b/_examples/widget_demos/theming/tabs/select_tab.go
@@ -7,7 +7,8 @@ import (
 )
 
 func NewSelectTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Select",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Select"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
 		),

--- a/_examples/widget_demos/theming/tabs/select_tab.go
+++ b/_examples/widget_demos/theming/tabs/select_tab.go
@@ -8,7 +8,9 @@ import (
 
 func NewSelectTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Select",
-		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		),
 	)
 
 	numEntries := 20

--- a/_examples/widget_demos/theming/tabs/slider_tab.go
+++ b/_examples/widget_demos/theming/tabs/slider_tab.go
@@ -7,7 +7,8 @@ import (
 )
 
 func NewSliderTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Slider",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Slider"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
 		),

--- a/_examples/widget_demos/theming/tabs/slider_tab.go
+++ b/_examples/widget_demos/theming/tabs/slider_tab.go
@@ -8,7 +8,9 @@ import (
 
 func NewSliderTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Slider",
-		widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewAnchorLayout()),
+		),
 	)
 
 	// construct a slider

--- a/_examples/widget_demos/theming/tabs/textarea_tab.go
+++ b/_examples/widget_demos/theming/tabs/textarea_tab.go
@@ -7,7 +7,8 @@ import (
 )
 
 func NewTextAreaTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Text Area",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Text Area"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewRowLayout(
 				widget.RowLayoutOpts.Direction(widget.DirectionVertical),

--- a/_examples/widget_demos/theming/tabs/textarea_tab.go
+++ b/_examples/widget_demos/theming/tabs/textarea_tab.go
@@ -8,11 +8,13 @@ import (
 
 func NewTextAreaTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Text Area",
-		widget.ContainerOpts.Layout(widget.NewRowLayout(
-			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
-			widget.RowLayoutOpts.Spacing(10),
-			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(20)),
-		)),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewRowLayout(
+				widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+				widget.RowLayoutOpts.Spacing(10),
+				widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(20)),
+			)),
+		),
 	)
 	// construct a textarea
 	textarea := widget.NewTextArea(

--- a/_examples/widget_demos/theming/tabs/textinput_tab.go
+++ b/_examples/widget_demos/theming/tabs/textinput_tab.go
@@ -9,7 +9,8 @@ import (
 )
 
 func NewTextInputTab() *widget.TabBookTab {
-	result := widget.NewTabBookTab("Text Input",
+	result := widget.NewTabBookTab(
+		widget.TabBookTabOpts.Label("Text Input"),
 		widget.TabBookTabOpts.ContainerOpts(
 			widget.ContainerOpts.Layout(widget.NewRowLayout(
 				widget.RowLayoutOpts.Direction(widget.DirectionVertical),

--- a/_examples/widget_demos/theming/tabs/textinput_tab.go
+++ b/_examples/widget_demos/theming/tabs/textinput_tab.go
@@ -10,11 +10,13 @@ import (
 
 func NewTextInputTab() *widget.TabBookTab {
 	result := widget.NewTabBookTab("Text Input",
-		widget.ContainerOpts.Layout(widget.NewRowLayout(
-			widget.RowLayoutOpts.Direction(widget.DirectionVertical),
-			widget.RowLayoutOpts.Spacing(10),
-			widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(20)),
-		)),
+		widget.TabBookTabOpts.ContainerOpts(
+			widget.ContainerOpts.Layout(widget.NewRowLayout(
+				widget.RowLayoutOpts.Direction(widget.DirectionVertical),
+				widget.RowLayoutOpts.Spacing(10),
+				widget.RowLayoutOpts.Padding(widget.NewInsetsSimple(20)),
+			)),
+		),
 	)
 
 	// construct a standard textinput widget

--- a/widget/button.go
+++ b/widget/button.go
@@ -857,6 +857,16 @@ func (b *Button) Text() *Text {
 	return b.text
 }
 
+func (b *Button) SetText(text string) {
+	b.init.Do()
+	b.textLabel = text
+}
+
+func (b *Button) SetGraphicImage(image *GraphicImage) {
+	b.init.Do()
+	b.definedParams.GraphicImage = image
+}
+
 func (b *Button) initWidget() {
 
 	if b.computedParams.MinSize != nil {

--- a/widget/button.go
+++ b/widget/button.go
@@ -860,7 +860,9 @@ func (b *Button) Text() *Text {
 func (b *Button) SetText(text string) {
 	b.init.Do()
 	b.textLabel = text
-	b.text.Label = text
+	if b.text != nil {
+		b.text.Label = text
+	}
 }
 
 func (b *Button) SetGraphicImage(image *GraphicImage) {

--- a/widget/button.go
+++ b/widget/button.go
@@ -860,11 +860,13 @@ func (b *Button) Text() *Text {
 func (b *Button) SetText(text string) {
 	b.init.Do()
 	b.textLabel = text
+	b.text.Label = text
 }
 
 func (b *Button) SetGraphicImage(image *GraphicImage) {
 	b.init.Do()
 	b.definedParams.GraphicImage = image
+	b.computedParams.GraphicImage = image
 }
 
 func (b *Button) initWidget() {

--- a/widget/tabbook.go
+++ b/widget/tabbook.go
@@ -373,7 +373,11 @@ func (t *TabBook) initTabBook() {
 		t.tabs[i].Validate()
 		btnOpts := []ButtonOpt{
 			ButtonOpts.Image(t.computedParams.TabButton.Image),
-			ButtonOpts.Text(t.tabs[i].label, t.computedParams.TabButton.TextFace, t.computedParams.TabButton.TextColor),
+		}
+		if t.tabs[i].image != nil {
+			btnOpts = append(btnOpts, ButtonOpts.TextAndImage(t.tabs[i].label, t.computedParams.TabButton.TextFace, t.tabs[i].image, t.computedParams.TabButton.TextColor))
+		} else {
+			btnOpts = append(btnOpts, ButtonOpts.Text(t.tabs[i].label, t.computedParams.TabButton.TextFace, t.computedParams.TabButton.TextColor))
 		}
 		if t.computedParams.TabButton.MinSize != nil {
 			btnOpts = append(btnOpts, ButtonOpts.WidgetOpts(WidgetOpts.MinSize(t.computedParams.TabButton.MinSize.X, t.computedParams.TabButton.MinSize.Y)))

--- a/widget/tabbook_test.go
+++ b/widget/tabbook_test.go
@@ -11,8 +11,8 @@ import (
 func TestTabBook_Tab_Initial(t *testing.T) {
 	is := is.New(t)
 
-	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
-	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab1 := NewTabBookTab(TabBookTabOpts.Label("Tab 1"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab(TabBookTabOpts.Label("Tab 2"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),
@@ -30,8 +30,8 @@ func TestTabBook_SetTab(t *testing.T) {
 	var eventArgs *TabBookTabSelectedEventArgs
 	numEvents := 0
 
-	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
-	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab1 := NewTabBookTab(TabBookTabOpts.Label("Tab 1"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab(TabBookTabOpts.Label("Tab 2"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),
@@ -58,8 +58,8 @@ func TestTabBook_TabSelectedEvent_User(t *testing.T) {
 	var eventArgs *TabBookTabSelectedEventArgs
 	numEvents := 0
 
-	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
-	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab1 := NewTabBookTab(TabBookTabOpts.Label("Tab 1"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab(TabBookTabOpts.Label("Tab 2"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),
@@ -81,9 +81,9 @@ func TestTabBook_TabSelectedEvent_User(t *testing.T) {
 func TestTabBook_GetTabButton(t *testing.T) {
 	is := is.New(t)
 
-	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
-	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
-	tab3 := NewTabBookTab("Tab 3", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab1 := NewTabBookTab(TabBookTabOpts.Label("Tab 1"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab(TabBookTabOpts.Label("Tab 2"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab3 := NewTabBookTab(TabBookTabOpts.Label("Tab 3"), TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),

--- a/widget/tabbook_test.go
+++ b/widget/tabbook_test.go
@@ -11,8 +11,8 @@ import (
 func TestTabBook_Tab_Initial(t *testing.T) {
 	is := is.New(t)
 
-	tab1 := NewTabBookTab("Tab 1", newTabContainerOpts()...)
-	tab2 := NewTabBookTab("Tab 2", newTabContainerOpts()...)
+	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),
@@ -30,8 +30,8 @@ func TestTabBook_SetTab(t *testing.T) {
 	var eventArgs *TabBookTabSelectedEventArgs
 	numEvents := 0
 
-	tab1 := NewTabBookTab("Tab 1", newTabContainerOpts()...)
-	tab2 := NewTabBookTab("Tab 2", newTabContainerOpts()...)
+	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),
@@ -58,8 +58,8 @@ func TestTabBook_TabSelectedEvent_User(t *testing.T) {
 	var eventArgs *TabBookTabSelectedEventArgs
 	numEvents := 0
 
-	tab1 := NewTabBookTab("Tab 1", newTabContainerOpts()...)
-	tab2 := NewTabBookTab("Tab 2", newTabContainerOpts()...)
+	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),
@@ -81,9 +81,9 @@ func TestTabBook_TabSelectedEvent_User(t *testing.T) {
 func TestTabBook_GetTabButton(t *testing.T) {
 	is := is.New(t)
 
-	tab1 := NewTabBookTab("Tab 1", newTabContainerOpts()...)
-	tab2 := NewTabBookTab("Tab 2", newTabContainerOpts()...)
-	tab3 := NewTabBookTab("Tab 3", newTabContainerOpts()...)
+	tab1 := NewTabBookTab("Tab 1", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab2 := NewTabBookTab("Tab 2", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
+	tab3 := NewTabBookTab("Tab 3", TabBookTabOpts.ContainerOpts(newTabContainerOpts()...))
 
 	tb := newTabBook(t,
 		TabBookOpts.Tabs(tab1, tab2),

--- a/widget/tabbooktab.go
+++ b/widget/tabbooktab.go
@@ -70,14 +70,6 @@ func NewTabBookTab(opts... TabBookTabOpt) *TabBookTab {
 	return c
 }
 
-func (t *TabBookTab) SetLabel(label string) {
-	t.label = label
-}
-
-func (t *TabBookTab) SetImage(img *GraphicImage) {
-	t.image = img
-}
-
 func (t *TabBookTab) Validate() {
 	t.Container.Validate()
 

--- a/widget/tabbooktab.go
+++ b/widget/tabbooktab.go
@@ -44,9 +44,14 @@ func (o *TabBookTabOptions) Image(img *GraphicImage) TabBookTabOpt {
 	}
 }
 
-func NewTabBookTab(label string, opts... TabBookTabOpt) *TabBookTab {
+func (o *TabBookTabOptions) Label(label string) TabBookTabOpt {
+	return func(t *TabBookTab) {
+		t.label = label
+	}
+}
+
+func NewTabBookTab(opts... TabBookTabOpt) *TabBookTab {
 	c := &TabBookTab{
-		label: label,
 	}
 	c.init = &MultiOnce{}
 	c.init.Append(c.createWidget)
@@ -63,6 +68,14 @@ func NewTabBookTab(label string, opts... TabBookTabOpt) *TabBookTab {
 		o(c)
 	}
 	return c
+}
+
+func (t *TabBookTab) SetLabel(label string) {
+	t.label = label
+}
+
+func (t *TabBookTab) SetImage(img *GraphicImage) {
+	t.image = img
 }
 
 func (t *TabBookTab) Validate() {

--- a/widget/tabbooktab.go
+++ b/widget/tabbooktab.go
@@ -8,6 +8,7 @@ type TabBookTab struct {
 	Container
 	Disabled bool
 	label    string
+	image   *GraphicImage
 }
 
 type TabBookTabSelectedEventArgs struct {
@@ -22,7 +23,28 @@ type TabParams struct {
 	BackgroundImage *image.NineSlice
 }
 
-func NewTabBookTab(label string, opts ...ContainerOpt) *TabBookTab {
+type TabBookTabOptions struct {
+}
+
+type TabBookTabOpt func(o *TabBookTab)
+
+var TabBookTabOpts TabBookTabOptions
+
+func (o *TabBookTabOptions) ContainerOpts(opts ...ContainerOpt) TabBookTabOpt {
+	return func(t *TabBookTab) {
+		for _, o := range opts {
+			o(&t.Container)
+		}
+	}
+}
+
+func (o *TabBookTabOptions) Image(img *GraphicImage) TabBookTabOpt {
+	return func(t *TabBookTab) {
+		t.image = img
+	}
+}
+
+func NewTabBookTab(label string, opts... TabBookTabOpt) *TabBookTab {
 	c := &TabBookTab{
 		label: label,
 	}
@@ -38,7 +60,7 @@ func NewTabBookTab(label string, opts ...ContainerOpt) *TabBookTab {
 	}))
 
 	for _, o := range opts {
-		o(&c.Container)
+		o(c)
 	}
 	return c
 }


### PR DESCRIPTION
This PR allows a user to add an image into a tab button.
`_examples/widget_demos/tabbook` shows a blue square on the blue tab

<img width="203" height="49" alt="image" src="https://github.com/user-attachments/assets/5410f80a-fd89-4c45-8e4c-9906ecf014c2" />

This is achieved by passing a GraphicImage down to the underlying Button object with the ButtonOpts.TextAndImage() option if the GraphicImage is not nil, otherwise the existing ButtonOpts.Text() is used.

This required creating a new TabBookTabOpts that the existing ContainerOpts are an option for, so rather than passing the ContainerOpts directly to a NewTabBookTab(), those container opts are wrapped like so
```
widget.NewTabBookTab("label", widget.TabBookTabOpts.ContainerOpts(widget.ContainerOpts.Layout(...), ...))
```
And the GraphicImage is just another TabBookTabOpts.Image(img) option.