### PR TITLE
list: add option to keep entries sorted

### DIFF
--- a/widget/list.go
+++ b/widget/list.go
@@ -51,6 +51,7 @@ type List struct {
 
 	entries        []any
 	entryLabelFunc ListEntryLabelFunc
+	entrySortFunc  ListEntrySortFunc
 
 	init            *MultiOnce
 	container       *Container
@@ -75,6 +76,7 @@ type List struct {
 type ListOpt func(l *List)
 
 type ListEntryLabelFunc func(e any) string
+type ListEntrySortFunc func(a, b any) int
 
 type ListEntryColor struct {
 	Unselected                 color.Color
@@ -337,13 +339,20 @@ func (o ListOptions) HideVerticalSlider() ListOpt {
 
 func (o ListOptions) Entries(e []any) ListOpt {
 	return func(l *List) {
-		l.entries = slices.CompactFunc(e, func(a any, b any) bool { return a == b })
+		l.entries = l.normalizeEntries(e)
 	}
 }
 
 func (o ListOptions) EntryLabelFunc(f ListEntryLabelFunc) ListOpt {
 	return func(l *List) {
 		l.entryLabelFunc = f
+	}
+}
+
+func (o ListOptions) EntrySortFunc(f ListEntrySortFunc) ListOpt {
+	return func(l *List) {
+		l.entrySortFunc = f
+		l.entries = l.normalizeEntries(l.entries)
 	}
 }
 
@@ -710,27 +719,11 @@ func (l *List) initWidget() {
 // Updates the entries in the list.
 // Note: Duplicates will be removed.
 func (l *List) SetEntries(newEntries []any) {
-	// Remove old entries
-	for i := range l.entries {
-		but := l.buttons[i]
-		l.listContent.RemoveChild(but)
-	}
-	l.entries = nil
-	l.buttons = nil
+	oldEntries := append([]any(nil), l.entries...)
+	oldButtons := append([]*Button(nil), l.buttons...)
 
-	// Add new Entries
-	for idx := range newEntries {
-		if !slices.ContainsFunc(l.entries, func(cmp any) bool {
-			return cmp == newEntries[idx]
-		}) {
-			l.entries = append(l.entries, newEntries[idx])
-			if l.validated {
-				but := l.createEntry(newEntries[idx])
-				l.buttons = append(l.buttons, but)
-				l.listContent.AddChild(but)
-			}
-		}
-	}
+	l.entries = l.normalizeEntries(newEntries)
+	l.syncButtonsToEntries(oldEntries, oldButtons)
 	l.selectedEntry = nil
 	l.resetFocusIndex()
 }
@@ -767,12 +760,11 @@ func (l *List) RemoveEntry(entry any) {
 func (l *List) AddEntry(entry any) {
 	l.init.Do()
 	if !l.checkForDuplicates(l.entries, entry) {
-		l.entries = append(l.entries, entry)
-		if l.validated {
-			but := l.createEntry(entry)
-			l.buttons = append(l.buttons, but)
-			l.listContent.AddChild(but)
-		}
+		oldEntries := append([]any(nil), l.entries...)
+		oldButtons := append([]*Button(nil), l.buttons...)
+
+		l.entries = l.normalizeEntries(append(l.entries, entry))
+		l.syncButtonsToEntries(oldEntries, oldButtons)
 	}
 	l.resetFocusIndex()
 }
@@ -826,6 +818,71 @@ func (l *List) checkForDuplicates(entries []any, entry any) bool {
 	return slices.ContainsFunc(entries, func(cmp any) bool {
 		return cmp == entry
 	})
+}
+
+func (l *List) normalizeEntries(entries []any) []any {
+	normalized := make([]any, 0, len(entries))
+	for _, entry := range entries {
+		if !l.checkForDuplicates(normalized, entry) {
+			normalized = append(normalized, entry)
+		}
+	}
+	if l.entrySortFunc != nil {
+		slices.SortStableFunc(normalized, l.entrySortFunc)
+	}
+	return normalized
+}
+
+func (l *List) syncButtonsToEntries(oldEntries []any, oldButtons []*Button) {
+	if !l.validated {
+		l.buttons = nil
+		return
+	}
+
+	newEntries := make([]any, len(l.entries))
+	copy(newEntries, l.entries)
+
+	newButtons := make([]*Button, 0, len(newEntries))
+	reusedButtons := make([]bool, len(oldButtons))
+
+	for _, entry := range newEntries {
+		reused := false
+		for i, oldEntry := range oldEntries {
+			if reusedButtons[i] {
+				continue
+			}
+			if oldEntry == entry {
+				newButtons = append(newButtons, oldButtons[i])
+				reusedButtons[i] = true
+				reused = true
+				break
+			}
+		}
+		if reused {
+			continue
+		}
+
+		but := l.createEntry(entry)
+		l.listContent.addChildInit(but)
+		newButtons = append(newButtons, but)
+	}
+
+	for i, oldButton := range oldButtons {
+		if !reusedButtons[i] {
+			closeWidget(oldButton.GetWidget())
+		}
+	}
+
+	l.buttons = newButtons
+
+	children := make([]PreferredSizeLocateableWidget, len(newButtons))
+	for i, but := range newButtons {
+		children[i] = but
+	}
+	l.listContent.children = children
+	l.listContent.RequestRelayout()
+	l.listContent.relayoutParent = true
+	l.listContent.closeEphemeralWindows = true
 }
 
 func (l *List) createEntry(entry any) *Button {

--- a/widget/list.go
+++ b/widget/list.go
@@ -719,11 +719,24 @@ func (l *List) initWidget() {
 // Updates the entries in the list.
 // Note: Duplicates will be removed.
 func (l *List) SetEntries(newEntries []any) {
-	oldEntries := append([]any(nil), l.entries...)
-	oldButtons := append([]*Button(nil), l.buttons...)
+	if l.validated {
+		for _, but := range l.buttons {
+			l.listContent.RemoveChild(but)
+		}
+	}
 
 	l.entries = l.normalizeEntries(newEntries)
-	l.syncButtonsToEntries(oldEntries, oldButtons)
+	l.buttons = nil
+
+	if l.validated {
+		l.buttons = make([]*Button, 0, len(l.entries))
+		for _, entry := range l.entries {
+			but := l.createEntry(entry)
+			l.buttons = append(l.buttons, but)
+			l.listContent.AddChild(but)
+		}
+	}
+
 	l.selectedEntry = nil
 	l.resetFocusIndex()
 }
@@ -760,11 +773,22 @@ func (l *List) RemoveEntry(entry any) {
 func (l *List) AddEntry(entry any) {
 	l.init.Do()
 	if !l.checkForDuplicates(l.entries, entry) {
-		oldEntries := append([]any(nil), l.entries...)
-		oldButtons := append([]*Button(nil), l.buttons...)
-
-		l.entries = l.normalizeEntries(append(l.entries, entry))
-		l.syncButtonsToEntries(oldEntries, oldButtons)
+		if l.entrySortFunc != nil {
+			index, _ := slices.BinarySearchFunc(l.entries, entry, l.entrySortFunc)
+			l.entries = slices.Insert(l.entries, index, entry)
+			if l.validated {
+				but := l.createEntry(entry)
+				l.buttons = slices.Insert(l.buttons, index, but)
+				l.insertListContentChild(index, but)
+			}
+		} else {
+			l.entries = append(l.entries, entry)
+			if l.validated {
+				but := l.createEntry(entry)
+				l.buttons = append(l.buttons, but)
+				l.listContent.AddChild(but)
+			}
+		}
 	}
 	l.resetFocusIndex()
 }
@@ -833,53 +857,9 @@ func (l *List) normalizeEntries(entries []any) []any {
 	return normalized
 }
 
-func (l *List) syncButtonsToEntries(oldEntries []any, oldButtons []*Button) {
-	if !l.validated {
-		l.buttons = nil
-		return
-	}
-
-	newEntries := make([]any, len(l.entries))
-	copy(newEntries, l.entries)
-
-	newButtons := make([]*Button, 0, len(newEntries))
-	reusedButtons := make([]bool, len(oldButtons))
-
-	for _, entry := range newEntries {
-		reused := false
-		for i, oldEntry := range oldEntries {
-			if reusedButtons[i] {
-				continue
-			}
-			if oldEntry == entry {
-				newButtons = append(newButtons, oldButtons[i])
-				reusedButtons[i] = true
-				reused = true
-				break
-			}
-		}
-		if reused {
-			continue
-		}
-
-		but := l.createEntry(entry)
-		l.listContent.addChildInit(but)
-		newButtons = append(newButtons, but)
-	}
-
-	for i, oldButton := range oldButtons {
-		if !reusedButtons[i] {
-			closeWidget(oldButton.GetWidget())
-		}
-	}
-
-	l.buttons = newButtons
-
-	children := make([]PreferredSizeLocateableWidget, len(newButtons))
-	for i, but := range newButtons {
-		children[i] = but
-	}
-	l.listContent.children = children
+func (l *List) insertListContentChild(index int, child PreferredSizeLocateableWidget) {
+	l.listContent.addChildInit(child)
+	l.listContent.children = slices.Insert(l.listContent.children, index, child)
 	l.listContent.RequestRelayout()
 	l.listContent.relayoutParent = true
 	l.listContent.closeEphemeralWindows = true

--- a/widget/list_test.go
+++ b/widget/list_test.go
@@ -2,6 +2,7 @@ package widget
 
 import (
 	"image/color"
+	"strconv"
 	"testing"
 
 	"github.com/ebitenui/ebitenui/event"
@@ -161,6 +162,67 @@ func TestList_EntrySelectedEvent_User_AllowReselect(t *testing.T) {
 	is.Equal(list.SelectedEntry(), entries[1])
 
 	is.Equal(numEvents, 2)
+}
+
+func TestList_Entries_SortedOnCreate(t *testing.T) {
+	is := is.New(t)
+
+	list := newList(t,
+		ListOpts.Entries([]interface{}{"third", "first", "second"}),
+		ListOpts.EntrySortFunc(func(a, b any) int {
+			left := a.(string)
+			right := b.(string)
+			switch {
+			case left < right:
+				return -1
+			case left > right:
+				return 1
+			default:
+				return 0
+			}
+		}),
+		ListOpts.EntryLabelFunc(func(e interface{}) string {
+			return e.(string)
+		}),
+	)
+
+	is.Equal(list.Entries()[0], "first")
+	is.Equal(list.Entries()[1], "second")
+	is.Equal(list.Entries()[2], "third")
+	is.Equal(list.buttons[0].Text().Label, "first")
+	is.Equal(list.buttons[1].Text().Label, "second")
+	is.Equal(list.buttons[2].Text().Label, "third")
+}
+
+func TestList_AddEntry_ResortsAndReusesButtons(t *testing.T) {
+	is := is.New(t)
+
+	list := newList(t,
+		ListOpts.Entries([]interface{}{2, 4}),
+		ListOpts.EntrySortFunc(func(a, b any) int {
+			return a.(int) - b.(int)
+		}),
+		ListOpts.EntryLabelFunc(func(e interface{}) string {
+			return strconv.Itoa(e.(int))
+		}),
+	)
+
+	button2 := list.buttons[0]
+	button4 := list.buttons[1]
+
+	list.AddEntry(3)
+
+	is.Equal(list.Entries()[0], 2)
+	is.Equal(list.Entries()[1], 3)
+	is.Equal(list.Entries()[2], 4)
+	is.Equal(list.buttons[0], button2)
+	is.Equal(list.buttons[2], button4)
+	is.Equal(list.buttons[1].Text().Label, "3")
+
+	children := list.listContent.Children()
+	is.Equal(children[0], button2)
+	is.Equal(children[1], list.buttons[1])
+	is.Equal(children[2], button4)
 }
 
 func newList(t *testing.T, opts ...ListOpt) *List {


### PR DESCRIPTION
This PR adds a ListOptions.EntrySortFunc that if set will keep the entries of the list in sorted order. The argument to EntrySortFunc is a func(any,any)int, that would be passed to slices.SortStableFunc to compare entries.

I tried to not have to recreate buttons for the entries unless necessary, but because the entry slice and the button slice are separate theres a lot of O(N^2) nested loops to keep things synchronized. It might be simpler to just make a combined struct that has both the entry and its associated button.